### PR TITLE
core: Remove duplicate configuration from custom config

### DIFF
--- a/core/res/res/values/evolution_config.xml
+++ b/core/res/res/values/evolution_config.xml
@@ -459,18 +459,6 @@
     -->
     <integer name="config_longPressOnBackBehavior">0</integer>
 
-    <!-- Control the behavior when the user long presses the home button.
-         This needs to match the enums in
-         frameworks/base/core/java/com/android/internal/util/custom/hwkeys/DeviceKeysConstants.java.
-    -->
-    <integer name="config_longPressOnHomeBehavior">@*android:integer/config_longPressOnHomeBehavior</integer>
-
-    <!-- Control the behavior when the user double-taps the home button.
-         This needs to match the enums in
-         frameworks/base/core/java/com/android/internal/util/custom/hwkeys/DeviceKeysConstants.java.
-    -->
-    <integer name="config_doubleTapOnHomeBehavior">@*android:integer/config_doubleTapOnHomeBehavior</integer>
-
     <!-- Control the behavior when the user long presses the menu button.
          This needs to match the enums in
          frameworks/base/core/java/com/android/internal/util/custom/hwkeys/DeviceKeysConstants.java.


### PR DESCRIPTION
```
frameworks/base/core/res/res/values/evolution_config.xml:472: error: resource 'integer/config_doubleTapOnHomeBehavior' has a conflicting value for configuration ().
frameworks/base/core/res/res/values/config.xml:1522: note: originally defined here.
frameworks/base/core/res/res/values/evolution_config.xml:466: error: resource 'integer/config_longPressOnHomeBehavior' has a conflicting value for configuration ().
frameworks/base/core/res/res/values/config.xml:1513: note: originally defined here.
out/soong/.intermediates/frameworks/base/core/res/framework-res/android_common/aapt2/frameworks/base/core/res/res/values_evolution_config.arsc.flat: error: failed to merge resource table.
error: failed parsing input.
```