### PR TITLE
[SQUASH] Treewide: Add Alert Slider user interface

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -6953,6 +6953,12 @@ public final class Settings {
         public static final String GAMESPACE_SUPPRESS_FULLSCREEN_INTENT = "gamespace_suppress_fullscreen_intent";
 
         /**
+         * Whether to show or hide alert slider notifications on supported devices
+         * @hide
+         */
+        public static final String ALERT_SLIDER_NOTIFICATIONS = "alert_slider_notifications";
+
+        /**
          * Keys we no longer back up under the current schema, but want to continue to
          * process when restoring historical backup datasets.
          *

--- a/core/res/res/values/evolution_config.xml
+++ b/core/res/res/values/evolution_config.xml
@@ -135,4 +135,15 @@
 
     <!-- Whether device has a centered display cutout -->
     <bool name="config_physicalDisplayCutoutCentered">@bool/config_physicalDisplayCutout</bool>
+
+    <!-- Whether device has physical tri state switch -->
+    <bool name="config_hasAlertSlider">false</bool>
+
+    <!-- The location of the devices physical tri state switch
+         0: Left side
+         1: Right side -->
+    <integer name="config_alertSliderLocation">0</integer>
+
+    <!-- Whether key handler sends intent when changing slider position -->
+    <string name="config_alertSliderIntent"></string>
 </resources>

--- a/core/res/res/values/evolution_symbols.xml
+++ b/core/res/res/values/evolution_symbols.xml
@@ -97,4 +97,13 @@
 
     <!-- Whether device has a big physical display cutout -->
     <java-symbol type="bool" name="config_physicalDisplayCutoutCentered" />
+
+    <!-- Whether device has physical tri state switch -->
+    <java-symbol type="bool" name="config_hasAlertSlider" />
+
+    <!-- The location of the devices physical tri state switch -->
+    <java-symbol type="integer" name="config_alertSliderLocation" />
+
+    <!-- Whether key handler sends intent when changing slider position -->
+    <java-symbol type="string" name="config_alertSliderIntent" />
 </resources>

--- a/packages/SystemUI/res/drawable/dialog_tri_state_middle_bg.xml
+++ b/packages/SystemUI/res/drawable/dialog_tri_state_middle_bg.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2019 CypherOS
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="#ff1d1d1d" />
+            <corners
+                android:topLeftRadius="@dimen/tri_state_mid_top_left_radius"
+                android:topRightRadius="@dimen/tri_state_mid_top_right_radius"
+                android:bottomLeftRadius="@dimen/tri_state_mid_bottom_left_radius"
+                android:bottomRightRadius="@dimen/tri_state_mid_bottom_right_radius" />
+        </shape>
+    </item>
+</layer-list>

--- a/packages/SystemUI/res/drawable/dialog_tri_state_middle_bg.xml
+++ b/packages/SystemUI/res/drawable/dialog_tri_state_middle_bg.xml
@@ -15,10 +15,11 @@
     limitations under the License.
 -->
 <layer-list
-  xmlns:android="http://schemas.android.com/apk/res/android">
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:androidprv="http://schemas.android.com/apk/prv/res/android">
     <item>
         <shape>
-            <solid android:color="#ff1d1d1d" />
+            <solid android:color="?androidprv:attr/colorSurface" />
             <corners
                 android:topLeftRadius="@dimen/tri_state_mid_top_left_radius"
                 android:topRightRadius="@dimen/tri_state_mid_top_right_radius"

--- a/packages/SystemUI/res/drawable/dialog_tri_state_navigation_bg.xml
+++ b/packages/SystemUI/res/drawable/dialog_tri_state_navigation_bg.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2019 CypherOS
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="#e6208de3" />
+            <corners
+                android:topLeftRadius="10.0dip"
+                android:topRightRadius="10.0dip"
+                android:bottomLeftRadius="10.0dip"
+                android:bottomRightRadius="10.0dip" />
+        </shape>
+    </item>
+</layer-list>

--- a/packages/SystemUI/res/drawable/dialog_tri_state_triangle_right.xml
+++ b/packages/SystemUI/res/drawable/dialog_tri_state_triangle_right.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2019 CypherOS
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/shape_id" android:height="42.0px">
+        <rotate android:layout_width="fill_parent" android:layout_height="wrap_content" android:fromDegrees="45.0" android:pivotX="0.0%" android:pivotY="0.0%">
+            <shape android:shape="rectangle">
+                <solid android:color="#ff000000" />
+                <size android:height="29.695984px" android:width="29.695984px" />
+            </shape>
+        </rotate>
+    </item>
+</layer-list>

--- a/packages/SystemUI/res/drawable/dialog_tri_state_triangle_top.xml
+++ b/packages/SystemUI/res/drawable/dialog_tri_state_triangle_top.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2019 CypherOS
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/shape_id" android:width="42.0px">
+        <rotate android:layout_width="fill_parent" android:layout_height="wrap_content" android:fromDegrees="45.0" android:pivotX="0.0%" android:pivotY="100.0%">
+            <shape android:shape="rectangle">
+                <solid android:color="#ff000000" />
+                <size android:height="29.695984px" android:width="29.695984px" />
+            </shape>
+        </rotate>
+    </item>
+</layer-list>

--- a/packages/SystemUI/res/drawable/ic_tristate_brightness_auto.xml
+++ b/packages/SystemUI/res/drawable/ic_tristate_brightness_auto.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="?android:attr/colorControlNormal" >
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M14.3,16L13.6,14H10.4L9.7,16H7.8L11,7H13L16.2,16H14.3M20,8.69V4H15.31L12,0.69L8.69,4H4V8.69L0.69,12L4,15.31V20H8.69L12,23.31L15.31,20H20V15.31L23.31,12L20,8.69M10.85,12.65H13.15L12,9L10.85,12.65Z" />
+</vector>

--- a/packages/SystemUI/res/drawable/ic_tristate_brightness_bright.xml
+++ b/packages/SystemUI/res/drawable/ic_tristate_brightness_bright.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="?android:attr/colorControlNormal" >
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6A6,6 0 0,1 18,12A6,6 0 0,1 12,18M20,15.31L23.31,12L20,8.69V4H15.31L12,0.69L8.69,4H4V8.69L0.69,12L4,15.31V20H8.69L12,23.31L15.31,20H20V15.31Z" />
+</vector>

--- a/packages/SystemUI/res/drawable/ic_tristate_brightness_dark.xml
+++ b/packages/SystemUI/res/drawable/ic_tristate_brightness_dark.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="?android:attr/colorControlNormal" >
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,18C11.11,18 10.26,17.8 9.5,17.45C11.56,16.5 13,14.42 13,12C13,9.58 11.56,7.5 9.5,6.55C10.26,6.2 11.11,6 12,6A6,6 0 0,1 18,12A6,6 0 0,1 12,18M20,8.69V4H15.31L12,0.69L8.69,4H4V8.69L0.69,12L4,15.31V20H8.69L12,23.31L15.31,20H20V15.31L23.31,12L20,8.69Z" />
+</vector>

--- a/packages/SystemUI/res/drawable/ic_tristate_flashlight.xml
+++ b/packages/SystemUI/res/drawable/ic_tristate_flashlight.xml
@@ -1,0 +1,11 @@
+<!-- drawable/flashlight.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="?android:attr/colorControlNormal" >
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9,10L6,5H18L15,10H9M18,4H6V2H18V4M9,22V11H15V22H9M12,13A1,1 0 0,0 11,14A1,1 0 0,0 12,15A1,1 0 0,0 13,14A1,1 0 0,0 12,13Z" />
+</vector>

--- a/packages/SystemUI/res/drawable/ic_tristate_flashlight_off.xml
+++ b/packages/SystemUI/res/drawable/ic_tristate_flashlight_off.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="?android:attr/colorControlNormal" >
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M2,5.27L3.28,4L20,20.72L18.73,22L15,18.27V22H9V12.27L2,5.27M18,5L15,10H11.82L6.82,5H18M18,4H6V2H18V4M15,11V13.18L12.82,11H15Z" />
+</vector>

--- a/packages/SystemUI/res/drawable/ic_tristate_rotate_auto.xml
+++ b/packages/SystemUI/res/drawable/ic_tristate_rotate_auto.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="?android:attr/colorControlNormal" >
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M7.5,21.5C4.25,19.94 1.91,16.76 1.55,13H0.05C0.56,19.16 5.71,24 12,24L12.66,23.97L8.85,20.16M14.83,21.19L2.81,9.17L9.17,2.81L21.19,14.83M10.23,1.75C9.64,1.16 8.69,1.16 8.11,1.75L1.75,8.11C1.16,8.7 1.16,9.65 1.75,10.23L13.77,22.25C14.36,22.84 15.31,22.84 15.89,22.25L22.25,15.89C22.84,15.3 22.84,14.35 22.25,13.77L10.23,1.75M16.5,2.5C19.75,4.07 22.09,7.24 22.45,11H23.95C23.44,4.84 18.29,0 12,0L11.34,0.03L15.15,3.84L16.5,2.5Z" />
+</vector>

--- a/packages/SystemUI/res/drawable/ic_tristate_rotate_landscape.xml
+++ b/packages/SystemUI/res/drawable/ic_tristate_rotate_landscape.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="?android:attr/colorControlNormal" >
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9,1H3A2,2 0 0,0 1,3V16A2,2 0 0,0 3,18H9A2,2 0 0,0 11,16V3A2,2 0 0,0 9,1M9,15H3V3H9V15M21,13H13V15H21V21H9V20H6V21A2,2 0 0,0 8,23H21A2,2 0 0,0 23,21V15A2,2 0 0,0 21,13M23,10L19,8L20.91,7.09C19.74,4.31 17,2.5 14,2.5V1A9,9 0 0,1 23,10Z" />
+</vector>

--- a/packages/SystemUI/res/drawable/ic_tristate_rotate_portrait.xml
+++ b/packages/SystemUI/res/drawable/ic_tristate_rotate_portrait.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="?android:attr/colorControlNormal" >
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9,1H3A2,2 0 0,0 1,3V16A2,2 0 0,0 3,18H4V15H3V3H9V11H11V3A2,2 0 0,0 9,1M23,21V15A2,2 0 0,0 21,13H8A2,2 0 0,0 6,15V21A2,2 0 0,0 8,23H21A2,2 0 0,0 23,21M9,21V15H21V21H9M23,10H21.5C21.5,7 19.69,4.27 16.92,3.09L16,5L14,1A9,9 0 0,1 23,10Z" />
+</vector>

--- a/packages/SystemUI/res/drawable/left_dialog_tri_state_down_bg.xml
+++ b/packages/SystemUI/res/drawable/left_dialog_tri_state_down_bg.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2019 CypherOS
+    Copyright (C) 2020 Paranoid Android
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="#ff1d1d1d" />
+            <corners
+                android:topLeftRadius="@dimen/left_tri_state_down_top_left_radius"
+                android:topRightRadius="@dimen/left_tri_state_down_top_right_radius"
+                android:bottomLeftRadius="@dimen/left_tri_state_down_bottom_left_radius"
+                android:bottomRightRadius="@dimen/left_tri_state_down_bottom_right_radius" />
+        </shape>
+    </item>
+</layer-list>

--- a/packages/SystemUI/res/drawable/left_dialog_tri_state_up_bg.xml
+++ b/packages/SystemUI/res/drawable/left_dialog_tri_state_up_bg.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2019 CypherOS
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="#ff1d1d1d" />
+            <corners
+                android:topLeftRadius="@dimen/left_tri_state_up_top_left_radius"
+                android:topRightRadius="@dimen/left_tri_state_up_top_right_radius"
+                android:bottomLeftRadius="@dimen/left_tri_state_up_bottom_left_radius"
+                android:bottomRightRadius="@dimen/left_tri_state_up_bottom_right_radius" />
+        </shape>
+    </item>
+</layer-list>

--- a/packages/SystemUI/res/drawable/right_dialog_tri_state_down_bg.xml
+++ b/packages/SystemUI/res/drawable/right_dialog_tri_state_down_bg.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2019 CypherOS
+    Copyright (C) 2020 Paranoid Android
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="#ff1d1d1d" />
+            <corners
+                android:topLeftRadius="@dimen/right_tri_state_down_top_left_radius"
+                android:topRightRadius="@dimen/right_tri_state_down_top_right_radius"
+                android:bottomLeftRadius="@dimen/right_tri_state_down_bottom_left_radius"
+                android:bottomRightRadius="@dimen/right_tri_state_down_bottom_right_radius" />
+        </shape>
+    </item>
+</layer-list>

--- a/packages/SystemUI/res/drawable/right_dialog_tri_state_up_bg.xml
+++ b/packages/SystemUI/res/drawable/right_dialog_tri_state_up_bg.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2019 CypherOS
+    Copyright (C) 2020 Paranoid Android
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="#ff1d1d1d" />
+            <corners
+                android:topLeftRadius="@dimen/right_tri_state_up_top_left_radius"
+                android:topRightRadius="@dimen/right_tri_state_up_top_right_radius"
+                android:bottomLeftRadius="@dimen/right_tri_state_up_bottom_left_radius"
+                android:bottomRightRadius="@dimen/right_tri_state_up_bottom_right_radius" />
+        </shape>
+    </item>
+</layer-list>

--- a/packages/SystemUI/res/layout/tri_state_dialog.xml
+++ b/packages/SystemUI/res/layout/tri_state_dialog.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2019 CypherOS
+    Copyright (C) 2020-2022 crDroid Android Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:paddingLeft="@dimen/tri_state_dialog_padding"
+    android:paddingTop="@dimen/tri_state_dialog_padding"
+    android:paddingRight="@dimen/tri_state_dialog_padding"
+    android:paddingBottom="@dimen/tri_state_dialog_padding"
+    android:clipToPadding="false"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_alignParentTop="true"
+    android:theme="@style/qs_theme">
+
+    <LinearLayout
+        android:layout_gravity="center|right"
+        android:orientation="horizontal"
+        android:id="@+id/tri_state_layout"
+        android:background="@drawable/dialog_tri_state_middle_bg"
+        android:layout_width="wrap_content"
+        android:layout_height="48.0dip"
+        android:translationZ="@dimen/tri_state_dialog_elevation">
+
+        <FrameLayout
+            android:layout_width="54.0dip"
+            android:layout_height="fill_parent">
+
+            <ImageView
+                android:layout_gravity="center"
+                android:id="@+id/tri_state_icon"
+                android:layout_marginLeft="2.0dip"
+                android:layout_width="@dimen/tri_state_dialog_icon_size"
+                android:layout_height="@dimen/tri_state_dialog_icon_size"
+                android:tint="@color/accent_tint_color_selector" />
+        </FrameLayout>
+
+        <TextView
+            android:gravity="center_vertical"
+            android:id="@+id/tri_state_text"
+            android:layout_width="wrap_content"
+            android:layout_height="fill_parent"
+            android:textSize="14.0sp"
+            android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
+            android:textColor="?android:attr/textColorPrimary" />
+
+        <FrameLayout
+            android:layout_width="18.0dip"
+            android:layout_height="fill_parent" />
+    </LinearLayout>
+</LinearLayout>

--- a/packages/SystemUI/res/values/evolution_dimens.xml
+++ b/packages/SystemUI/res/values/evolution_dimens.xml
@@ -51,4 +51,37 @@
 
     <!-- Maximum vertical offset of navigation bar for burn-in protection -->
     <dimen name="navigation_bar_burn_in_offset_max_y">8dp</dimen>
+    
+    <!-- Tri-state UI -->
+    <dimen name="tri_state_down_dialog_position">850.0px</dimen>
+    <dimen name="tri_state_down_dialog_position_l">650.0px</dimen>
+    <dimen name="tri_state_middle_dialog_position">650.0px</dimen>
+    <dimen name="tri_state_middle_dialog_position_l">650.0px</dimen>
+    <dimen name="tri_state_up_dialog_position">450.0px</dimen>
+    <dimen name="tri_state_up_dialog_position_l">650.0px</dimen>
+    <dimen name="tri_state_up_dialog_position_deep">21.0px</dimen>
+    <dimen name="tri_state_up_dialog_position_deep_land">21.0px</dimen>
+    <dimen name="tri_state_dialog_elevation">4.0dip</dimen>
+    <dimen name="tri_state_dialog_icon_size">24.0dip</dimen>
+    <dimen name="tri_state_dialog_padding">8.0dip</dimen>
+    <dimen name="tri_state_mid_bottom_left_radius">24.0dip</dimen>
+    <dimen name="tri_state_mid_bottom_right_radius">24.0dip</dimen>
+    <dimen name="tri_state_mid_top_left_radius">24.0dip</dimen>
+    <dimen name="tri_state_mid_top_right_radius">24.0dip</dimen>
+    <dimen name="left_tri_state_down_bottom_left_radius">24.0dip</dimen>
+    <dimen name="left_tri_state_down_bottom_right_radius">24.0dip</dimen>
+    <dimen name="left_tri_state_down_top_left_radius">0.0dip</dimen>
+    <dimen name="left_tri_state_down_top_right_radius">24.0dip</dimen>
+    <dimen name="left_tri_state_up_bottom_left_radius">0.0dip</dimen>
+    <dimen name="left_tri_state_up_bottom_right_radius">24.0dip</dimen>
+    <dimen name="left_tri_state_up_top_left_radius">24.0dip</dimen>
+    <dimen name="left_tri_state_up_top_right_radius">24.0dip</dimen>
+    <dimen name="right_tri_state_down_bottom_left_radius">24.0dip</dimen>
+    <dimen name="right_tri_state_down_bottom_right_radius">24.0dip</dimen>
+    <dimen name="right_tri_state_down_top_left_radius">24.0dip</dimen>
+    <dimen name="right_tri_state_down_top_right_radius">0.0dip</dimen>
+    <dimen name="right_tri_state_up_bottom_left_radius">24.0dip</dimen>
+    <dimen name="right_tri_state_up_bottom_right_radius">0.0dip</dimen>
+    <dimen name="right_tri_state_up_top_left_radius">24.0dip</dimen>
+    <dimen name="right_tri_state_up_top_right_radius">24.0dip</dimen>
 </resources>

--- a/packages/SystemUI/res/values/evolution_strings.xml
+++ b/packages/SystemUI/res/values/evolution_strings.xml
@@ -141,4 +141,20 @@
 
     <!-- DC Dimming -->
     <string name="quick_settings_dc_dimming_label">DC Dimming</string>
+
+    <!-- Alert slide extras -->
+    <string name="volume_ringer_priority_only">Priority</string>
+    <string name="volume_ringer_alarms_only">Alarms</string>
+    <string name="volume_ringer_dnd">DnD</string>
+    <string name="tristate_flashlight">Torch</string>
+    <string name="tristate_flashlight_on">Torch on</string>
+    <string name="tristate_flashlight_off">Torch off</string>
+    <string name="tristate_flashlight_blink">Torch blink</string>
+    <string name="tristate_brightness_bright">Max-brightness</string>
+    <string name="tristate_brightness_dark">Min-brightness</string>
+    <string name="tristate_brightness_auto">Auto-brightness</string>
+    <string name="tristate_rotation_auto">Auto-rotate</string>
+    <string name="tristate_rotation_0">Portrait</string>
+    <string name="tristate_rotation_90">Landscape (90°)</string>
+    <string name="tristate_rotation_270">Landscape (270°)</string>
 </resources>

--- a/packages/SystemUI/res/values/evolution_styles.xml
+++ b/packages/SystemUI/res/values/evolution_styles.xml
@@ -4,7 +4,6 @@
      SPDX-License-Identifier: Apache-2.0
 -->
 <resources>
-
     <!-- Island notification -->
     <style name="Theme.Island.SystemUI" parent="@style/Theme.MaterialComponents.DayNight">
         <item name="android:fontFamily">@*android:string/config_bodyFontFamily</item>
@@ -22,4 +21,8 @@
         <item name="android:fontFamily">@*android:string/config_bodyFontFamily</item>
     </style>
 
+    <!-- Tri-state UI -->
+    <style name="qs_theme" parent="Theme.SystemUI.QuickSettings">
+        <item name="android:windowIsFloating">true</item>
+    </style>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/tristate/TriStateUiController.java
+++ b/packages/SystemUI/src/com/android/systemui/tristate/TriStateUiController.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 CypherOS
+ * Copyright 2014-2019 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.tristate;
+
+import com.android.systemui.plugins.Plugin;
+import com.android.systemui.plugins.VolumeDialog.Callback;
+import com.android.systemui.plugins.annotations.DependsOn;
+import com.android.systemui.plugins.annotations.ProvidesInterface;
+
+@DependsOn(target = Callback.class)
+@ProvidesInterface(action = "com.android.systemui.action.PLUGIN_TRI_STATE_UI", version = 1)
+public interface TriStateUiController extends Plugin {
+
+    public interface UserActivityListener {
+        void onTriStateUserActivity();
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/tristate/TriStateUiControllerImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/tristate/TriStateUiControllerImpl.java
@@ -585,7 +585,7 @@ public class TriStateUiControllerImpl implements TriStateUiController,
                     }
                     if (mDialogView != null && bg != 0) {
                         mDialogView.setBackgroundDrawable(res.getDrawable(bg));
-                        mBackgroundColor = getAttrColor(android.R.attr.colorPrimary);
+                        mBackgroundColor = getAttrColor(com.android.internal.R.attr.colorSurface);
                         mDialogView.setBackgroundTintList(ColorStateList.valueOf(mBackgroundColor));
                     }
                     mDialogPosition = positionY2;

--- a/packages/SystemUI/src/com/android/systemui/tristate/TriStateUiControllerImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/tristate/TriStateUiControllerImpl.java
@@ -1,0 +1,671 @@
+/*
+ * Copyright (C) 2019 CypherOS
+ *           (C) 2014-2020 Paranoid Android
+ *           (C) 2020-2023 crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.tristate;
+
+import static android.view.Surface.ROTATION_90;
+import static android.view.Surface.ROTATION_180;
+import static android.view.Surface.ROTATION_270;
+
+import android.app.Dialog;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.res.ColorStateList;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.hardware.display.DisplayManagerGlobal;
+import android.media.AudioManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import android.provider.Settings;
+import android.util.DisplayUtils;
+import android.util.Log;
+import android.view.ContextThemeWrapper;
+import android.view.Display;
+import android.view.OrientationEventListener;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager.LayoutParams;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.android.systemui.R;
+import com.android.systemui.tristate.TriStateUiController;
+import com.android.systemui.tristate.TriStateUiController.UserActivityListener;
+import com.android.systemui.plugins.VolumeDialogController;
+import com.android.systemui.plugins.VolumeDialogController.Callbacks;
+import com.android.systemui.plugins.VolumeDialogController.State;
+import com.android.systemui.statusbar.policy.ConfigurationController;
+import com.android.systemui.tuner.TunerService;
+
+public class TriStateUiControllerImpl implements TriStateUiController,
+        ConfigurationController.ConfigurationListener, TunerService.Tunable {
+
+
+    private static String TAG = "TriStateUiControllerImpl";
+
+    public static final String ALERT_SLIDER_NOTIFICATIONS =
+            "system:" + Settings.System.ALERT_SLIDER_NOTIFICATIONS;
+
+    private static final int MSG_DIALOG_SHOW = 1;
+    private static final int MSG_DIALOG_DISMISS = 2;
+    private static final int MSG_RESET_SCHEDULE = 3;
+    private static final int MSG_STATE_CHANGE = 4;
+
+    private static final int RINGER_MODE_NORMAL = AudioManager.RINGER_MODE_NORMAL;
+    private static final int RINGER_MODE_SILENT = AudioManager.RINGER_MODE_SILENT;
+    private static final int RINGER_MODE_VIBRATE = AudioManager.RINGER_MODE_VIBRATE;
+
+    private static final int POSITION_TOP = 0;
+    private static final int POSITION_MIDDLE = 1;
+    private static final int POSITION_BOTTOM = 2;
+
+    // Slider
+    private static final int MODE_TOTAL_SILENCE = 600;
+    private static final int MODE_ALARMS_ONLY = 601;
+    private static final int MODE_PRIORITY_ONLY = 602;
+    private static final int MODE_NONE = 603;
+    private static final int MODE_VIBRATE = 604;
+    private static final int MODE_RING = 605;
+    // Arbitrary value which hopefully doesn't conflict with upstream anytime soon
+    private static final int MODE_SILENT = 620;
+    private static final int MODE_FLASHLIGHT_ON = 621;
+    private static final int MODE_FLASHLIGHT_OFF = 622;
+    private static final int MODE_FLASHLIGHT_BLINK = 623;
+    private static final int MODE_BRIGHTNESS_BRIGHT = 630;
+    private static final int MODE_BRIGHTNESS_DARK = 631;
+    private static final int MODE_BRIGHTNESS_AUTO = 632;
+    private static final int MODE_ROTATION_AUTO = 640;
+    private static final int MODE_ROTATION_0 = 641;
+    private static final int MODE_ROTATION_90 = 642;
+    private static final int MODE_ROTATION_270 = 643;
+
+    private static final String EXTRA_SLIDER_POSITION = "position";
+    private static final String EXTRA_SLIDER_POSITION_VALUE = "position_value";
+
+    private static final int TRI_STATE_UI_POSITION_LEFT = 0;
+    private static final int TRI_STATE_UI_POSITION_RIGHT = 1;
+
+    private static final long DIALOG_TIMEOUT = 2000;
+    private static final long DIALOG_DELAY = 300;
+
+    private Context mContext;
+    private final VolumeDialogController mVolumeDialogController;
+    private final ConfigurationController mConfigurationController;
+    private final TunerService mTunerService;
+
+    private final Callbacks mVolumeDialogCallback = new Callbacks() {
+        @Override
+        public void onShowRequested(int reason, boolean keyguardLocked, int lockTaskModeState) { }
+
+        @Override
+        public void onDismissRequested(int reason) { }
+
+        @Override
+        public void onScreenOff() { }
+
+        @Override
+        public void onStateChanged(State state) { }
+
+        @Override
+        public void onLayoutDirectionChanged(int layoutDirection) { }
+
+        @Override
+        public void onShowVibrateHint() { }
+
+        @Override
+        public void onShowSilentHint() { }
+
+        @Override
+        public void onShowSafetyWarning(int flags) { }
+
+        @Override
+        public void onShowCsdWarning(int csdWarning, int durationMs) { }
+
+        @Override
+        public void onAccessibilityModeChanged(Boolean showA11yStream) { }
+
+        @Override
+        public void onCaptionComponentStateChanged(
+                Boolean isComponentEnabled, Boolean fromTooltip) {}
+
+        @Override
+        public void onCaptionEnabledStateChanged(Boolean isEnabled, Boolean checkBeforeSwitch) {}
+
+        @Override
+        public void onConfigurationChanged() {
+            updateTriStateLayout();
+        }
+	// Android 14 QPR3 merge fix up
+        @Override
+	public void onVolumeChangedFromKey() { }
+    };
+
+    private int mDensity;
+    private Dialog mDialog;
+    private int mDialogPosition;
+    private ViewGroup mDialogView;
+    private final H mHandler;
+    private UserActivityListener mListener;
+    OrientationEventListener mOrientationListener;
+    private int mOrientationType = 0;
+    private boolean mShowing = false;
+    private int mBackgroundColor = 0;
+    private ImageView mTriStateIcon;
+    private TextView mTriStateText;
+    private int mTriStateMode = -1;
+    private int mPosition = -1;
+    private int mPositionValue = -1;
+    private Window mWindow;
+    private LayoutParams mWindowLayoutParams;
+    private int mWindowType;
+    private String mIntentAction;
+    private boolean mIntentActionSupported;
+    private boolean mRingModeChanged;
+    private boolean mSliderPositionChanged;
+    private boolean mAlertSliderNotification;
+
+    private final BroadcastReceiver mSliderStateReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (!mAlertSliderNotification) {
+                mRingModeChanged = false;
+                mSliderPositionChanged = false;
+                return;
+            }
+
+            String action = intent.getAction();
+            if (mIntentActionSupported && action.equals(mIntentAction)) {
+                Bundle extras = intent.getExtras();
+                mPosition = extras.getInt(EXTRA_SLIDER_POSITION);
+                mPositionValue = extras.getInt(EXTRA_SLIDER_POSITION_VALUE);
+                mHandler.sendEmptyMessage(MSG_DIALOG_DISMISS);
+                mHandler.sendEmptyMessage(MSG_STATE_CHANGE);
+                mSliderPositionChanged = true;
+                Log.d(TAG, "received slider position " + mPosition
+                                    + " with value " + mPositionValue);
+            } else if (!mIntentActionSupported && action.equals(AudioManager.RINGER_MODE_CHANGED_ACTION)) {
+                mHandler.sendEmptyMessage(MSG_DIALOG_DISMISS);
+                mHandler.sendEmptyMessage(MSG_STATE_CHANGE);
+                mRingModeChanged = true;
+            }
+
+            if (mRingModeChanged || mSliderPositionChanged) {
+                mRingModeChanged = false;
+                mSliderPositionChanged = false;
+                if (mTriStateMode != -1) {
+                    mHandler.sendEmptyMessageDelayed(MSG_DIALOG_SHOW, (long) DIALOG_DELAY);
+               }
+            }
+        }
+    };
+
+    private final class H extends Handler {
+        private TriStateUiControllerImpl mUiController;
+
+        public H(TriStateUiControllerImpl uiController) {
+            super(Looper.getMainLooper());
+            mUiController = uiController;
+        }
+
+        public void handleMessage(Message msg) {
+            switch (msg.what) {
+                case MSG_DIALOG_SHOW:
+                    mUiController.handleShow();
+                    return;
+                case MSG_DIALOG_DISMISS:
+                    mUiController.handleDismiss();
+                    return;
+                case MSG_RESET_SCHEDULE:
+                    mUiController.handleResetTimeout();
+                    return;
+                case MSG_STATE_CHANGE:
+                    mUiController.handleStateChanged();
+                    return;
+                default:
+                    return;
+            }
+        }
+    }
+
+    public TriStateUiControllerImpl(
+            Context context,
+            VolumeDialogController volumeDialogController,
+            ConfigurationController configurationController,
+            TunerService tunerService) {
+        mContext =
+                new ContextThemeWrapper(context, R.style.qs_theme);
+        mVolumeDialogController = volumeDialogController;
+        mConfigurationController = configurationController;
+        mTunerService = tunerService;
+        mHandler = new H(this);
+        mOrientationListener = new OrientationEventListener(mContext, 3) {
+            @Override
+            public void onOrientationChanged(int orientation) {
+                checkOrientationType();
+            }
+        };
+        mIntentAction = context.getResources().getString(com.android.internal.R.string.config_alertSliderIntent);
+        mIntentActionSupported = mIntentAction != null && !mIntentAction.isEmpty();
+
+        IntentFilter filter = new IntentFilter();
+        if (mIntentActionSupported) {
+            filter.addAction(mIntentAction);
+        } else {
+            filter.addAction(AudioManager.RINGER_MODE_CHANGED_ACTION);
+        }
+        mContext.registerReceiver(mSliderStateReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
+    }
+
+    @Override
+    public void onTuningChanged(String key, String newValue) {
+        switch (key) {
+            case ALERT_SLIDER_NOTIFICATIONS:
+                mAlertSliderNotification
+                        = TunerService.parseIntegerSwitch(newValue, true);
+                mHandler.sendEmptyMessage(MSG_DIALOG_DISMISS);
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public void onUiModeChanged() {
+        mContext.getTheme().applyStyle(mContext.getThemeResId(), true);
+        initDialog();
+    }
+
+    private void checkOrientationType() {
+        Display display = DisplayManagerGlobal.getInstance().getRealDisplay(0);
+        if (display != null) {
+            int rotation = display.getRotation();
+            if (rotation != mOrientationType) {
+                mOrientationType = rotation;
+                updateTriStateLayout();
+            }
+        }
+    }
+
+    public void init(int windowType, UserActivityListener listener) {
+        mWindowType = windowType;
+        mDensity = mContext.getResources().getConfiguration().densityDpi;
+        mListener = listener;
+        mConfigurationController.addCallback(this);
+        mVolumeDialogController.addCallback(mVolumeDialogCallback, mHandler);
+        mTunerService.addTunable(this, ALERT_SLIDER_NOTIFICATIONS);
+        initDialog();
+    }
+
+    public void destroy() {
+        mTunerService.removeTunable(this);
+        mConfigurationController.removeCallback(this);
+        mVolumeDialogController.removeCallback(mVolumeDialogCallback);
+        mContext.unregisterReceiver(mSliderStateReceiver);
+    }
+
+    private void initDialog() {
+        if (mDialog != null) {
+            mDialog.dismiss();
+            mDialog = null;
+        }
+        mDialog = new Dialog(mContext, R.style.qs_theme);
+        mShowing = false;
+        mWindow = mDialog.getWindow();
+        mWindow.requestFeature(Window.FEATURE_NO_TITLE);
+        mWindow.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        mWindow.clearFlags(LayoutParams.FLAG_DIM_BEHIND
+                | LayoutParams.FLAG_LAYOUT_INSET_DECOR);
+        mWindow.addFlags(LayoutParams.FLAG_NOT_FOCUSABLE
+                | LayoutParams.FLAG_LAYOUT_IN_SCREEN
+                | LayoutParams.FLAG_NOT_TOUCH_MODAL
+                | LayoutParams.FLAG_SHOW_WHEN_LOCKED
+                | LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH
+                | LayoutParams.FLAG_HARDWARE_ACCELERATED);
+        mWindow.setType(LayoutParams.TYPE_VOLUME_OVERLAY);
+        mWindow.setWindowAnimations(com.android.internal.R.style.Animation_Toast);
+        mDialog.setCanceledOnTouchOutside(false);
+        mWindowLayoutParams = mWindow.getAttributes();
+        mWindowLayoutParams.type = mWindowType;
+        mWindowLayoutParams.format = -3;
+        mWindowLayoutParams.setTitle(TriStateUiControllerImpl.class.getSimpleName());
+        mWindowLayoutParams.gravity = 53;
+        mWindowLayoutParams.y = mDialogPosition;
+        mWindow.setAttributes(mWindowLayoutParams);
+        mWindow.setSoftInputMode(LayoutParams.SOFT_INPUT_ADJUST_NOTHING);
+        mDialog.setContentView(R.layout.tri_state_dialog);
+        mDialogView = (ViewGroup) mDialog.findViewById(R.id.tri_state_layout);
+        mTriStateIcon = (ImageView) mDialog.findViewById(R.id.tri_state_icon);
+        mTriStateText = (TextView) mDialog.findViewById(R.id.tri_state_text);
+    }
+
+    private void registerOrientationListener(boolean enable) {
+        if (mOrientationListener.canDetectOrientation() && enable) {
+            Log.v(TAG, "Can detect orientation");
+            mOrientationListener.enable();
+            return;
+        }
+        Log.v(TAG, "Cannot detect orientation");
+        mOrientationListener.disable();
+    }
+
+    private void updateTriStateLayout() {
+        if (mContext != null) {
+            int iconId = 0;
+            int textId = 0;
+            int bg = 0;
+            Resources res = mContext.getResources();
+            if (res != null) {
+                int positionY;
+                int positionY2 = mWindowLayoutParams.y;
+                int positionX = mWindowLayoutParams.x;
+                int gravity = mWindowLayoutParams.gravity;
+                switch (mTriStateMode) {
+                    case MODE_RING:
+                    case MODE_NONE:
+                    case RINGER_MODE_NORMAL:
+                        iconId = R.drawable.ic_volume_ringer;
+                        textId = R.string.volume_ringer_status_normal;
+                        break;
+                    case MODE_VIBRATE:
+                    case RINGER_MODE_VIBRATE:
+                        iconId = R.drawable.ic_volume_ringer_vibrate;
+                        textId = R.string.volume_ringer_status_vibrate;
+                        break;
+                    case MODE_SILENT:
+                    case RINGER_MODE_SILENT:
+                        iconId = R.drawable.ic_volume_ringer_mute;
+                        textId = R.string.volume_ringer_status_silent;
+                        break;
+                    case MODE_PRIORITY_ONLY:
+                        iconId = R.drawable.ic_qs_dnd_on;
+                        textId = R.string.volume_ringer_priority_only;
+                        break;
+                    case MODE_ALARMS_ONLY:
+                        iconId = R.drawable.ic_qs_dnd_on;
+                        textId = R.string.volume_ringer_alarms_only;
+                        break;
+                    case MODE_TOTAL_SILENCE:
+                        iconId = R.drawable.ic_qs_dnd_on;
+                        textId = R.string.volume_ringer_dnd;
+                        break;
+                    case MODE_FLASHLIGHT_ON:
+                        iconId = R.drawable.ic_tristate_flashlight;
+                        textId = R.string.tristate_flashlight_on;
+                        break;
+                    case MODE_FLASHLIGHT_OFF:
+                        iconId = R.drawable.ic_tristate_flashlight_off;
+                        textId = R.string.tristate_flashlight_off;
+                        break;
+                    case MODE_FLASHLIGHT_BLINK:
+                        iconId = R.drawable.ic_tristate_flashlight;
+                        textId = R.string.tristate_flashlight_blink;
+                        break;
+                    case MODE_BRIGHTNESS_BRIGHT:
+                        iconId = R.drawable.ic_tristate_brightness_bright;
+                        textId = R.string.tristate_brightness_bright;
+                        break;
+                    case MODE_BRIGHTNESS_DARK:
+                        iconId = R.drawable.ic_tristate_brightness_dark;
+                        textId = R.string.tristate_brightness_dark;
+                        break;
+                    case MODE_BRIGHTNESS_AUTO:
+                        iconId = R.drawable.ic_tristate_brightness_auto;
+                        textId = R.string.tristate_brightness_auto;
+                        break;
+                    case MODE_ROTATION_AUTO:
+                        iconId = R.drawable.ic_tristate_rotate_auto;
+                        textId = R.string.tristate_rotation_auto;
+                        break;
+                    case MODE_ROTATION_0:
+                        iconId = R.drawable.ic_tristate_rotate_portrait;
+                        textId = R.string.tristate_rotation_0;
+                        break;
+                    case MODE_ROTATION_90:
+                        iconId = R.drawable.ic_tristate_rotate_landscape;
+                        textId = R.string.tristate_rotation_90;
+                        break;
+                    case MODE_ROTATION_270:
+                        iconId = R.drawable.ic_tristate_rotate_landscape;
+                        textId = R.string.tristate_rotation_270;
+                        break;
+                }
+
+                int triStatePos = res.getInteger(com.android.internal.R.integer.config_alertSliderLocation);
+                boolean isTsKeyRight = true;
+                if (triStatePos == TRI_STATE_UI_POSITION_LEFT) {
+                    isTsKeyRight = false;
+                } else if (triStatePos == TRI_STATE_UI_POSITION_RIGHT) {
+                    isTsKeyRight = true;
+                }
+                switch (mOrientationType) {
+                    case ROTATION_90:
+                        if (isTsKeyRight) {
+                            gravity = 51;
+                        } else {
+                            gravity = 83;
+                        }
+                        positionY2 = res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position_deep_land);
+                        if (isTsKeyRight) {
+                            positionY2 += res.getDimensionPixelSize(com.android.internal.R.dimen.status_bar_height);
+                        }
+                        if (mPosition == POSITION_TOP) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position_l);
+                        } else if (mPosition == POSITION_MIDDLE) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_middle_dialog_position_l);
+                        } else if (mPosition == POSITION_BOTTOM) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_down_dialog_position_l);
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_SILENT) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position_l);
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_VIBRATE) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_middle_dialog_position_l);
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_NORMAL) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_down_dialog_position_l);
+                        }
+                        bg = R.drawable.dialog_tri_state_middle_bg;
+                        break;
+                    case ROTATION_180:
+                        if (isTsKeyRight) {
+                            gravity = 83;
+                        } else {
+                            gravity = 85;
+                        }
+                        positionX = res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position_deep);
+                        positionY = res.getDimensionPixelSize(R.dimen.status_bar_height);
+                        if (mPosition == POSITION_TOP) {
+                            positionY += res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position);
+                            bg = !isTsKeyRight ? R.drawable.right_dialog_tri_state_down_bg : R.drawable.left_dialog_tri_state_down_bg;
+                        } else if (mPosition == POSITION_MIDDLE) {
+                            positionY += res.getDimensionPixelSize(R.dimen.tri_state_middle_dialog_position);
+                            bg = R.drawable.dialog_tri_state_middle_bg;
+                        } else if (mPosition == POSITION_BOTTOM) {
+                            positionY += res.getDimensionPixelSize(R.dimen.tri_state_down_dialog_position);
+                            bg = !isTsKeyRight ? R.drawable.right_dialog_tri_state_up_bg : R.drawable.left_dialog_tri_state_up_bg;
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_SILENT) {
+                            positionY += res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position);
+                            bg = !isTsKeyRight ? R.drawable.right_dialog_tri_state_down_bg : R.drawable.left_dialog_tri_state_down_bg;
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_VIBRATE) {
+                            positionY += res.getDimensionPixelSize(R.dimen.tri_state_middle_dialog_position);
+                            bg = R.drawable.dialog_tri_state_middle_bg;
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_NORMAL) {
+                            positionY += res.getDimensionPixelSize(R.dimen.tri_state_down_dialog_position);
+                            bg = !isTsKeyRight ? R.drawable.right_dialog_tri_state_up_bg : R.drawable.left_dialog_tri_state_up_bg;
+                        }
+                        positionY2 = positionY;
+                        break;
+                    case ROTATION_270:
+                        if (isTsKeyRight) {
+                            gravity = 85;
+                        } else {
+                            gravity = 53;
+                        }
+                        positionY2 = res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position_deep_land);
+                        if (!isTsKeyRight) {
+                            positionY2 += res.getDimensionPixelSize(com.android.internal.R.dimen.status_bar_height);
+                        }
+                        if (mPosition == POSITION_TOP) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position_l);
+                        } else if (mPosition == POSITION_MIDDLE) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_middle_dialog_position_l);
+                        } else if (mPosition == POSITION_BOTTOM) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_down_dialog_position_l);
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_SILENT) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position_l);
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_VIBRATE) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_middle_dialog_position_l);
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_NORMAL) {
+                            positionX = res.getDimensionPixelSize(R.dimen.tri_state_down_dialog_position_l);
+                        }
+                        bg = R.drawable.dialog_tri_state_middle_bg;
+                        break;
+                    default:
+                        if (isTsKeyRight) {
+                            gravity = 53;
+                        } else {
+                            gravity = 51;
+                        }
+                        positionX = res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position_deep);
+                        if (mPosition == POSITION_TOP) {
+                            positionY2 = res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position);
+                            bg = isTsKeyRight ? R.drawable.right_dialog_tri_state_up_bg : R.drawable.left_dialog_tri_state_up_bg;
+                        } else if (mPosition == POSITION_MIDDLE) {
+                            positionY2 = res.getDimensionPixelSize(R.dimen.tri_state_middle_dialog_position);
+                            bg = R.drawable.dialog_tri_state_middle_bg;
+                        } else if (mPosition == POSITION_BOTTOM) {
+                            positionY2 = res.getDimensionPixelSize(R.dimen.tri_state_down_dialog_position);
+                            bg = isTsKeyRight ? R.drawable.right_dialog_tri_state_down_bg : R.drawable.left_dialog_tri_state_down_bg;
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_SILENT) {
+                            positionY2 = res.getDimensionPixelSize(R.dimen.tri_state_up_dialog_position);
+                            bg = isTsKeyRight ? R.drawable.right_dialog_tri_state_up_bg : R.drawable.left_dialog_tri_state_up_bg;
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_VIBRATE) {
+                            positionY2 = res.getDimensionPixelSize(R.dimen.tri_state_middle_dialog_position);
+                            bg = R.drawable.dialog_tri_state_middle_bg;
+                        } else if (!mIntentActionSupported && mTriStateMode == RINGER_MODE_NORMAL) {
+                            positionY2 = res.getDimensionPixelSize(R.dimen.tri_state_down_dialog_position);
+                            bg = isTsKeyRight ? R.drawable.right_dialog_tri_state_down_bg : R.drawable.left_dialog_tri_state_down_bg;
+                        }
+                        positionY2 += res.getDimensionPixelSize(com.android.internal.R.dimen.status_bar_height);
+                        break;
+                }
+                if (mTriStateMode != -1) {
+                    if (mTriStateIcon != null && iconId != 0) {
+                        mTriStateIcon.setImageResource(iconId);
+                    }
+                    if (mTriStateText != null && textId != 0) {
+                        String inputText = res.getString(textId);
+                        if (inputText != null && mTriStateText.length() == inputText.length()) {
+                            StringBuilder sb = new StringBuilder();
+                            sb.append(inputText);
+                            sb.append(" ");
+                            inputText = sb.toString();
+                        }
+                        mTriStateText.setText(inputText);
+                    }
+                    if (mDialogView != null && bg != 0) {
+                        mDialogView.setBackgroundDrawable(res.getDrawable(bg));
+                        mBackgroundColor = getAttrColor(android.R.attr.colorPrimary);
+                        mDialogView.setBackgroundTintList(ColorStateList.valueOf(mBackgroundColor));
+                    }
+                    mDialogPosition = positionY2;
+                }
+
+                final float scaleFactor = DisplayUtils.getScaleFactor(mContext);
+
+                positionY = res.getDimensionPixelSize(R.dimen.tri_state_dialog_padding);
+                mWindowLayoutParams.gravity = gravity;
+                mWindowLayoutParams.y = (int) ((positionY2 - positionY) * scaleFactor);
+                mWindowLayoutParams.x = (int) ((positionX - positionY) * scaleFactor);
+                mWindow.setAttributes(mWindowLayoutParams);
+                mHandler.sendEmptyMessageDelayed(MSG_RESET_SCHEDULE, DIALOG_TIMEOUT);
+            }
+        }
+    }
+
+    private void handleShow() {
+        mHandler.removeMessages(MSG_DIALOG_SHOW);
+        if (!mShowing) {
+            registerOrientationListener(true);
+            checkOrientationType();
+            mShowing = true;
+            mDialog.show();
+            if (mListener != null) {
+                mListener.onTriStateUserActivity();
+            }
+            mHandler.sendEmptyMessageDelayed(MSG_RESET_SCHEDULE, DIALOG_TIMEOUT);
+        }
+    }
+
+    private void handleDismiss() {
+        mHandler.removeMessages(MSG_DIALOG_DISMISS);
+        if (mShowing) {
+            registerOrientationListener(false);
+            mShowing = false;
+            mDialog.dismiss();
+        }
+    }
+
+    private void handleStateChanged() {
+        mHandler.removeMessages(MSG_STATE_CHANGE);
+        if (mIntentActionSupported && mPositionValue != mTriStateMode) {
+            mTriStateMode = mPositionValue;
+            updateTriStateLayout();
+            if (mListener != null) {
+                mListener.onTriStateUserActivity();
+            }
+        } else if (!mIntentActionSupported) {
+            AudioManager am = (AudioManager) mContext.getSystemService(Context.AUDIO_SERVICE);
+            int ringerMode = am.getRingerModeInternal();
+            if (ringerMode != mTriStateMode) {
+                mTriStateMode = ringerMode;
+                updateTriStateLayout();
+                if (mListener != null) {
+                    mListener.onTriStateUserActivity();
+                }
+            }
+        }
+    }
+
+    public void handleResetTimeout() {
+        mHandler.removeMessages(MSG_RESET_SCHEDULE);
+        mHandler.sendEmptyMessage(MSG_DIALOG_DISMISS);
+        if (mListener != null) {
+            mListener.onTriStateUserActivity();
+        }
+    }
+
+    @Override
+    public void onDensityOrFontScaleChanged() {
+        mHandler.sendEmptyMessage(MSG_DIALOG_DISMISS);
+        initDialog();
+        updateTriStateLayout();
+    }
+
+    public int getAttrColor(int attr) {
+        TypedArray ta = mContext.obtainStyledAttributes(new int[]{attr});
+        int colorAccent = ta.getColor(0, 0);
+        ta.recycle();
+        return colorAccent;
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogComponent.java
+++ b/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogComponent.java
@@ -30,12 +30,15 @@ import com.android.settingslib.applications.InterestingConfigChanges;
 import com.android.systemui.dagger.SysUISingleton;
 import com.android.systemui.demomode.DemoMode;
 import com.android.systemui.demomode.DemoModeController;
+import com.android.systemui.tristate.TriStateUiController;
+import com.android.systemui.tristate.TriStateUiControllerImpl;
 import com.android.systemui.keyguard.KeyguardViewMediator;
 import com.android.systemui.plugins.ActivityStarter;
 import com.android.systemui.plugins.PluginDependencyProvider;
 import com.android.systemui.plugins.VolumeDialog;
 import com.android.systemui.plugins.VolumeDialogController;
 import com.android.systemui.qs.tiles.DndTile;
+import com.android.systemui.statusbar.policy.ConfigurationController;
 import com.android.systemui.statusbar.policy.ExtensionController;
 import com.android.systemui.tuner.TunerService;
 
@@ -50,7 +53,7 @@ import javax.inject.Inject;
  */
 @SysUISingleton
 public class VolumeDialogComponent implements VolumeComponent, TunerService.Tunable,
-        VolumeDialogControllerImpl.UserActivityListener{
+        VolumeDialogControllerImpl.UserActivityListener, TriStateUiController.UserActivityListener {
 
     public static final String VOLUME_DOWN_SILENT = "sysui_volume_down_silent";
     public static final String VOLUME_UP_SILENT = "sysui_volume_up_silent";
@@ -67,6 +70,7 @@ public class VolumeDialogComponent implements VolumeComponent, TunerService.Tuna
 
     protected final Context mContext;
     private final VolumeDialogControllerImpl mController;
+    private TriStateUiControllerImpl mTriStateController;
     private final InterestingConfigChanges mConfigChanges = new InterestingConfigChanges(
             ActivityInfo.CONFIG_FONT_SCALE | ActivityInfo.CONFIG_LOCALE
             | ActivityInfo.CONFIG_ASSETS_PATHS | ActivityInfo.CONFIG_UI_MODE);
@@ -81,6 +85,7 @@ public class VolumeDialogComponent implements VolumeComponent, TunerService.Tuna
             KeyguardViewMediator keyguardViewMediator,
             ActivityStarter activityStarter,
             VolumeDialogControllerImpl volumeDialogController,
+            ConfigurationController configurationController,
             DemoModeController demoModeController,
             PluginDependencyProvider pluginDependencyProvider,
             ExtensionController extensionController,
@@ -91,6 +96,8 @@ public class VolumeDialogComponent implements VolumeComponent, TunerService.Tuna
         mActivityStarter = activityStarter;
         mController = volumeDialogController;
         mController.setUserActivityListener(this);
+        boolean hasAlertSlider = mContext.getResources().
+                getBoolean(com.android.internal.R.bool.config_hasAlertSlider);
         // Allow plugins to reference the VolumeDialogController.
         pluginDependencyProvider.allowPluginDependency(VolumeDialogController.class);
         extensionController.newExtension(VolumeDialog.class)
@@ -102,6 +109,14 @@ public class VolumeDialogComponent implements VolumeComponent, TunerService.Tuna
                     }
                     mDialog = dialog;
                     mDialog.init(LayoutParams.TYPE_VOLUME_OVERLAY, mVolumeDialogCallback);
+                    if (hasAlertSlider) {
+                        if (mTriStateController != null) {
+                            mTriStateController.destroy();
+                        }
+                        mTriStateController = new TriStateUiControllerImpl(mContext,
+                            volumeDialogController, configurationController, tunerService);
+                        mTriStateController.init(LayoutParams.TYPE_VOLUME_OVERLAY, this);
+                    }
                 }).build();
 
 
@@ -202,6 +217,11 @@ public class VolumeDialogComponent implements VolumeComponent, TunerService.Tuna
 
     private void startSettings(Intent intent) {
         mActivityStarter.startActivity(intent, true /* onlyProvisioned */, true /* dismissShade */);
+    }
+
+    @Override
+    public void onTriStateUserActivity() {
+        onUserActivity();
     }
 
     private final VolumeDialogImpl.Callback mVolumeDialogCallback = new VolumeDialogImpl.Callback() {


### PR DESCRIPTION
Alert slider user interface works properly on my OnePlus 6T, with correct hardware tree settings. I also fixed up for A14 QPR3 merge.

Sorry, I couldn't reopen pr #28 , so I created a new one, if you feel good please merge, thank you!

Commit message:
```
Ported from OxygenOS and reworked for our alert slider implementation. We target AudioManager instead of Zen, icons are also the same as aosp and the dialog uses the material theme as well as support for our themes.

To use, the alert slider config must be enabled. By default, the dialog shows on the left side. To move it to the right side, set the location config to 1.

Squashed:

    From: ZVNexus <zvnexus@outlook.com>
    Date: Fri, 24 Jan 2020 17:00:41 -0500
    Subject: AlertSlider: Make tri-state SystemUI dialog dimensions conditional

    Adjust this based on the left/right config.

    From: Pranav Vashi <neobuddy89@gmail.com>
    Date: Sun, 23 Feb 2020 17:13:34 +0530
    Subject: AlertSlider: Work better with Key Handlers

    * Let Key Handler send intent to let know slider movement.
    * Helps not showing dialog every time ringer changes.

    From: Pranav Vashi <neobuddy89@gmail.com>
    Date: Sun, 23 Feb 2020 23:38:41 +0530
    Subject: AlertSlider: Do not hardcode slider position based on ringer mode

    * Let Key Handler send position details. Different ringer options can be now assigned to different position.
    * Also increase dialog show timeout slightly to avoid race with Key Handler.

    From: Hikari-no-Tenshi <kyryljan.serhij@gmail.com>
    Date: Mon, 24 Feb 2020 22:44:49 +0200
    Subject: AlertSlider: Use default position behaviour if position not specified in intent

    From: Pranav Vashi <neobuddy89@gmail.com>
    Date: Sun, 1 Mar 2020 00:38:13 +0530
    Subject: AlertSlider: Improve layout

    From: Ali B <abittin@gmail.com>
    Date: Sat, 14 Mar 2020 00:19:59 +0300
    Subject: AlertSlider: refactor to reflect slider state

    As there is the possibility of having more option values
    for the alertslider (such as various zen mode states)
    in addition to the current ringer mode states,
    update logic to reflect the value slider's position is
    set to instead of the ringer state we were using before.

    From: Ali B <abittin@gmail.com>
    Date: Mon, 23 Mar 2020 22:49:23 +0300
    Subject: AlertSlider: Update resources

    From: Pranav Vashi <neobuddy89@gmail.com>
    Date: Sun, 7 Feb 2021 12:07:58 +0530
    Subject: AlertSlider: Fix layout for 180 rotation

    From: Pranav Vashi <neobuddy89@gmail.com>
    Date: Sun, 7 Feb 2021 09:20:22 +0530
    Subject: AlertSlider: Add more resources

    From: Pranav Vashi <neobuddy89@gmail.com>
    Date: Sun, 7 Feb 2021 02:08:38 +0530
    Subject: AlertSlider: Prevent crash in case of incomplete broadcast

    * In intent extra EXTRA_SLIDER_POSITION_VALUE is not received and slider is changed,
      SystemUI will crash "No resource found". This patch should prevent such ice-cold havoc.

    From: Pranav Vashi <neobuddy89@gmail.com>
    Date: Tue, 23 Mar 2021 07:38:35 +0530
    Subject: AlertSlider: Update theme more swiftly

    From: Pranav Vashi <neobuddy89@gmail.com>
    Date: Fri, 28 Feb 2020 00:19:59 +0530
    Subject: AlertSlider: Add toggle to disable notifications [1/2]

    From: Pranav Vashi <neobuddy89@gmail.com>
    Date: Sun, 7 Feb 2021 12:08:16 +0530
    Subject: AlertSlider: Support slider actions without broadcast from device

    * Let's not lose purpose of original commit where intent broadcast was not introduced.
      Partially reverts 9241e52089404ead465c0ee5d48cdefa90b4809b

    From: idoybh <idoybh2@gmail.com>
    Date: Sun, 8 Aug 2021 15:49:16 +0200
    Subject: AlertSlider: check for existing dialog before creating new

    From: AnierinB <anierin@evolution-x.org>
    Date: Sun, 18 Sep 2022 14:52:24 +0200
    Subject: AlertSlider: Allow UI to work with multiple resolutions

    * Device side dimen overlays should reflect the maximum resolution.
    * Inspired by: https://review.lineageos.org/c/LineageOS/android_frameworks_base/+/339290
    * Migrate to DisplayUtils.getScaleFactor

    @neobuddy89:
    Clean up redundancy chaos.

    From: Pranav Vashi <neobuddy89@gmail.com>
    Date: Wed, 1 Nov 2023 13:37:17 +0530
    Subject: AlertSlider: Fixup implementation on A14

    Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>



@uwu-gl:
Also fix up for Android 14 QPR3.
```