### PR TITLE
BootAnimation: Fix race condition for custom animations on encrypted …

### DIFF
--- a/cmds/bootanimation/BootAnimation.cpp
+++ b/cmds/bootanimation/BootAnimation.cpp
@@ -34,6 +34,7 @@
 #include <utils/Trace.h>
 #include <signal.h>
 #include <time.h>
+#include <unistd.h>
 
 #include <cutils/properties.h>
 
@@ -722,6 +723,19 @@ bool BootAnimation::preloadAnimation() {
 bool BootAnimation::findBootAnimationFileInternal(const std::vector<std::string> &files) {
     ATRACE_CALL();
     for (const std::string& f : files) {
+        if (f.find("/data/") == 0) {
+            int attempts = 0;
+            const int max_attempts = 100; // 100 * 100ms = 10 seconds max wait
+            const int sleep_interval_us = 100000; // 100ms
+
+            while (access(f.c_str(), R_OK) != 0 && attempts < max_attempts) {
+                if (attempts % 10 == 0) {
+                    ALOGW("Custom bootanim: Waiting for %s... (%d/%d)", f.c_str(), attempts + 1, max_attempts);
+                }
+                usleep(sleep_interval_us);
+                attempts++;
+            }
+        }
         if (access(f.c_str(), R_OK) == 0) {
             mZipFileName = f.c_str();
             return true;


### PR DESCRIPTION
*Problem
Custom boot animations stored in `/data/misc/bootanim/bootanimation.zip` often fail to load on encrypted devices. This happens because the `bootanim` service starts significantly earlier than the `mount_all --late` trigger which mounts the `/data` partition. As a result, `access(path, R_OK)` fails immediately, and the system falls back to the stock animation.

*Solution
Instead of failing immediately when a file in `/data/` is not found, this patch implements a retry mechanism:
- Checks if the target path starts with `/data/`.
- If access fails, it enters a wait loop.
- Retries up to 100 times with a 100ms delay (max 10 seconds wait).
- Aborts the wait as soon as the file becomes readable.

This approach fixes the race condition without delaying the startup of the bootanimation service itself (which would happen if we moved the service start to `post-fs-data` in init.rc).