### PR TITLE
PixelPropsUtils: Implement Play Store spoof (spoofBuildVending()) [1/2]

### DIFF
--- a/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
@@ -67,11 +67,13 @@ public final class PixelPropsUtils {
     private static final String PACKAGE_GOOGLE = "com.google";
     private static final String PACKAGE_NEXUS_LAUNCHER = "com.google.android.apps.nexuslauncher";
     private static final String PACKAGE_SI = "com.google.android.settings.intelligence";
+    private static final String PACKAGE_VENDING = "com.android.vending";
 
     private static final String PROP_HOOKS = "persist.sys.pihooks_";
     private static final String SPOOF_PP = "persist.sys.pp";
     private static final String ENABLE_GAME_PROP_OPTIONS = "persist.sys.gameprops.enabled";
     public static final String SPOOF_GMS = "persist.sys.pp.gms";
+    private static final String SPOOF_VENDING = "persist.sys.pp.vending";
 
     private static final String TAG = PixelPropsUtils.class.getSimpleName();
     private static final boolean DEBUG = false;
@@ -148,10 +150,16 @@ public final class PixelPropsUtils {
         "TAGS", "TYPE", "SDK_INT"
     };
 
+    private static final String[] VENDING_SPOOF_KEYS = {
+        "BRAND", "DEVICE", "DEVICE_INITIAL_SDK_INT", "FINGERPRINT", "ID",
+        "MANUFACTURER", "MODEL", "PRODUCT", "RELEASE", "SECURITY_PATCH",
+        "TAGS", "TYPE"
+    };
+
     private static final ComponentName GMS_ADD_ACCOUNT_ACTIVITY = ComponentName.unflattenFromString(
             "com.google.android.gms/.auth.uiflows.minutemaid.MinuteMaidActivity");
 
-    private static volatile boolean sIsGms, sIsExcluded;
+    private static volatile boolean sIsGms, sIsVending, sIsExcluded;
     private static volatile String sProcessName;
 
     static {
@@ -253,17 +261,27 @@ public final class PixelPropsUtils {
         }
     }
 
+    public static void spoofBuildVending() {
+        if (!SystemProperties.getBoolean(SPOOF_VENDING, true))
+            return;
+        for (String key : VENDING_SPOOF_KEYS) {
+            setPropValue(key, SystemProperties.get(PROP_HOOKS + key));
+        }
+    }
+
     public static void setProps(Context context) {
         final String packageName = context.getPackageName();
         final String processName = Application.getProcessName();
         Map<String, Object> propsToChange = new HashMap<>();
         sProcessName = processName;
         sIsGms = packageName.equals(PACKAGE_GMS) && processName.equals(PROCESS_GMS_UNSTABLE);
+        sIsVending = packageName.equals(PACKAGE_VENDING);
         sIsExcluded = isGoogleCameraPackage(packageName);
         String model = SystemProperties.get("ro.product.model");
         boolean isPixelDevice = SystemProperties.get("ro.soc.manufacturer").equalsIgnoreCase("Google");
         boolean isMainlineDevice = isPixelDevice && model.matches("Pixel (8|9|10)[a-zA-Z ]*");
         boolean isPixelGmsEnabled = SystemProperties.getBoolean(SPOOF_GMS, true);
+        boolean isPixelVendingEnabled = SystemProperties.getBoolean(SPOOF_VENDING, true) && isPixelGmsEnabled;
         propsToChangeGeneric.forEach((k, v) -> setPropValue(k, v));
         setGameProps(packageName);
 
@@ -278,6 +296,15 @@ public final class PixelPropsUtils {
         if (sIsExcluded) {
             return;
         }
+
+        if (sIsVending) {
+            if (!isPixelVendingEnabled) {
+                return;
+            } else {
+                spoofBuildVending();
+            }
+        }
+
         if (sIsGms) {
             if (shouldTryToCertifyDevice()) {
                 if (!isPixelGmsEnabled) {


### PR DESCRIPTION
Spoofing the Play store (com.android.vending) with the same build as GMS (without SDK) will fix passing device integrity with a keybox.