### PR TITLE
Update CE storage handling in StorageManagerService

### DIFF
--- a/services/core/java/com/android/server/StorageManagerService.java
+++ b/services/core/java/com/android/server/StorageManagerService.java
@@ -3765,11 +3765,15 @@ class StorageManagerService extends IStorageManager.Stub
         final int userId = UserHandle.getUserId(callingUid);
         final String propertyName = "sys.user." + userId + ".ce_available";
 
-        // Ignore requests to create directories while CE storage is locked
         if (!isCeStorageUnlocked(userId)) {
-            throw new IllegalStateException("Failed to prepare " + appPath);
-        }
-
+    // If the directory already exists, the hardware is clearly unlocked.
+    // We log a warning but allow the code to continue to the vold call.
+    if (new File(appPath).exists()) {
+        Slog.w(TAG, "Storage reported locked, but path exists. Proceeding for: " + appPath);
+    } else {
+        throw new IllegalStateException("Failed to prepare " + appPath);
+    }
+}
         // Ignore requests to create directories if CE storage is not available
         if ((userId == UserHandle.USER_SYSTEM)
                 && !SystemProperties.getBoolean(propertyName, false)) {


### PR DESCRIPTION
Allow proceeding if directory exists despite locked CE storage.

Fixes Android/data folder creation on some apps dues to race condition.

02-12 06:42:13.214  2176 17668 W StorageManagerService: Failed to get storage lifetime
02-12 06:42:13.214  2176 17668 I StorageManagerService: Turn off gc_urgent based on checking lifetime and charge status
02-12 06:42:13.214  2176 17668 I StorageManagerService: Set smart idle maintenance: latest write amount: 244, average write amount: 0, min segment threshold: 512, dirty reclaim rate: 0.5, segment reclaim weight: 2.0, period(min): 60, min gc sleep time(ms): 5000, target dirty ratio: 100
02-12 06:51:02.679 18324 18339 W ContextImpl: 	at android.os.storage.IStorageManager$Stub$Proxy.mkdirs(IStorageManager.java:1305)
02-12 06:51:02.679 18324 18339 W ContextImpl: 	at android.os.storage.StorageManager.mkdirs(StorageManager.java:1421)
02-12 06:51:02.679 18324 18339 W ContextImpl: 	at com.android.server.StorageManagerService.mkdirs(StorageManagerService.java:3776)
02-12 06:51:02.679 18324 18339 W ContextImpl: 	at android.os.storage.IStorageManager$Stub.onTransact(IStorageManager.java:648)