### PR TITLE
VibratorInfo: Don't log error when frequency profile is absent

### DIFF
--- a/core/java/android/os/VibratorInfo.java
+++ b/core/java/android/os/VibratorInfo.java
@@ -690,6 +690,15 @@ public class VibratorInfo implements Parcelable {
 
             mResonantFrequencyHz = resonantFrequencyHz;
 
+            if (frequenciesHz == null && outputAccelerationsGs == null) {
+                mFrequenciesHz = null;
+                mOutputAccelerationsGs = null;
+                mMinFrequencyHz = Float.NaN;
+                mMaxFrequencyHz = Float.NaN;
+                mMaxOutputAccelerationGs = Float.NaN;
+                return;
+            }
+
             boolean isValid = (frequenciesHz != null && outputAccelerationsGs != null)
                     && (frequenciesHz.length == outputAccelerationsGs.length)
                     && (frequenciesHz.length > 0);


### PR DESCRIPTION
HALs that don't report CAP_FREQUENCY_CONTROL (e.g. AIDL V1) have no frequency profile data. The framework creates FrequencyProfile with null arrays and NaN resonant frequency, which is a valid 'no data' state — not an error.

Before this change, the constructor logged an ERROR-level message:
  Invalid frequency profile received from HAL. resonantFrequencyHz=NaN,
  frequenciesHz=null, outputAccelerationsGs=null

This spams logcat on every boot for devices with older vibrator HALs that work perfectly fine without frequency control.

Add an early return when both frequency arrays are null, silently setting all profile fields to null/NaN. The error log is preserved for genuinely invalid states (e.g. mismatched array lengths, one array null but the other non-null).