### PR TITLE
base: Empty accessibility service list when hiding app list

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -109,6 +109,7 @@ import com.android.internal.annotations.GuardedBy;
 import com.android.internal.util.Preconditions;
 
 import com.android.internal.util.evolution.HideDeveloperStatusUtils;
+import com.android.internal.util.evolution.HideAppListUtils;
 
 import java.io.IOException;
 import java.lang.annotation.ElementType;
@@ -3733,6 +3734,10 @@ public final class Settings {
                 final @CanBeCURRENT @UserIdInt int userId) {
             if (HideDeveloperStatusUtils.shouldHideDevStatus(cr, cr.getPackageName(), name)) {
                 return "0" /* Disabled */;
+            }
+            if (name.equals(Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES) 
+            && HideAppListUtils.shouldHideAppList(cr, cr.getPackageName())) {
+                return "";
             }
             final boolean isSelf = (userId == UserHandle.myUserId());
             final AttributionSource attributionSource = cr.getAttributionSource();
@@ -8480,6 +8485,11 @@ public final class Settings {
             if (HideDeveloperStatusUtils.shouldHideDevStatus(resolver, resolver.getPackageName(), name)) {
                 return "0" /* Disabled */;
             }
+
+            if (name.equals(Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES) 
+            && HideAppListUtils.shouldHideAppList(resolver, resolver.getPackageName())) {
+                return "";
+            }
             return getStringForUser(resolver, name, resolver.getUserId());
         }
 
@@ -8489,6 +8499,10 @@ public final class Settings {
                 @CanBeCURRENT @UserIdInt int userId) {
             if (HideDeveloperStatusUtils.shouldHideDevStatus(resolver, resolver.getPackageName(), name)) {
                 return "0" /* Disabled */;
+            }
+            if (name.equals(Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES) 
+            && HideAppListUtils.shouldHideAppList(resolver, resolver.getPackageName())) {
+                return "";
             }
             if (MOVED_TO_GLOBAL.contains(name)) {
                 Log.w(TAG, "Setting " + name + " has moved from android.provider.Settings.Secure"
@@ -23053,6 +23067,10 @@ public final class Settings {
             ContentResolver resolver = getContentResolver();
             if (HideDeveloperStatusUtils.shouldHideDevStatus(resolver, resolver.getPackageName(), name)) {
                 return "0" /* Disabled */;
+            }
+            if (name.equals(Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES) 
+            && HideAppListUtils.shouldHideAppList(resolver, resolver.getPackageName())) {
+                return "";
             }
             return sNameValueCache.getStringForUser(resolver, name, resolver.getUserId());
         }

--- a/services/accessibility/java/com/android/server/accessibility/AccessibilityManagerService.java
+++ b/services/accessibility/java/com/android/server/accessibility/AccessibilityManagerService.java
@@ -237,6 +237,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import com.android.internal.util.evolution.HideAppListUtils;
+
 /**
  * This class is instantiated by the system as a system level service and can be
  * accessed only by the system. The task of this service is to be a centralized
@@ -1566,6 +1568,11 @@ public class AccessibilityManagerService extends IAccessibilityManager.Stub
     @RequiresNoPermission
     public List<AccessibilityServiceInfo> getEnabledAccessibilityServiceList(int feedbackType,
             int userId) {
+
+        String[] pkgs = mContext.getPackageManager().getPackagesForUid(Binder.getCallingUid());
+        if (HideAppListUtils.shouldHideAppList(mContext, pkgs[0])) {
+            return Collections.emptyList();
+        }
         if (mTraceManager.isA11yTracingEnabledForTypes(FLAGS_ACCESSIBILITY_MANAGER)) {
             mTraceManager.logTrace(LOG_TAG + ".getEnabledAccessibilityServiceList",
                     FLAGS_ACCESSIBILITY_MANAGER,


### PR DESCRIPTION
Some apps like to block usage when there's an acessibility service enabled.

