### PR TITLE
base: fix AppOps, IME, FGS manager and log access edge cases

### DIFF
--- a/core/java/android/view/InsetsController.java
+++ b/core/java/android/view/InsetsController.java
@@ -1259,13 +1259,16 @@ public class InsetsController implements WindowInsetsController, InsetsAnimation
 
     public void hide(@InsetsType int types, @Nullable ImeTracker.Token statsToken) {
         if ((types & ime()) != 0) {
-            ProtoLog.d(IME_INSETS_CONTROLLER, "hide(ime())");
+            if ((mRequestedVisibleTypes & ime()) != 0
+                    || getAnimationType(ime()) == ANIMATION_TYPE_USER) {
+                ProtoLog.d(IME_INSETS_CONTROLLER, "hide(ime())");
 
-            if (statsToken == null) {
-                statsToken = ImeTracker.forLogging().onStart(ImeTracker.TYPE_HIDE,
-                        ImeTracker.ORIGIN_CLIENT,
-                        SoftInputShowHideReason.HIDE_SOFT_INPUT_BY_INSETS_API,
-                        mHost.isHandlingPointerEvent() /* fromUser */);
+                if (statsToken == null) {
+                    statsToken = ImeTracker.forLogging().onStart(ImeTracker.TYPE_HIDE,
+                            ImeTracker.ORIGIN_CLIENT,
+                            SoftInputShowHideReason.HIDE_SOFT_INPUT_BY_INSETS_API,
+                            mHost.isHandlingPointerEvent() /* fromUser */);
+                }
             }
         }
         Trace.asyncTraceBegin(TRACE_TAG_VIEW, "IC.hideRequestFromApi", 0);

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -1186,4 +1186,8 @@
 
     <!-- Indicates whether the tapping to open qs panel is supported -->
     <bool name="config_statusBarTapToExpandShade">false</bool>
+
+    <!-- Packages to be hidden from the FGS manager. -->
+    <string-array name="config_hideFgsManagerPackages" translatable="false">
+    </string-array>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/logcat/LogAccessDialogActivity.java
+++ b/packages/SystemUI/src/com/android/systemui/logcat/LogAccessDialogActivity.java
@@ -138,6 +138,12 @@ public class LogAccessDialogActivity extends Activity implements
         }
     }
 
+    @Override
+    protected void onDestroy() {
+        mHandler.removeMessages(MSG_DISMISS_DIALOG);
+        super.onDestroy();
+    }
+
     private boolean readIntentInfo(Intent intent) {
         if (intent == null) {
             Slog.e(TAG, "Intent is null");
@@ -246,7 +252,9 @@ public class LogAccessDialogActivity extends Activity implements
         } catch (RemoteException ignored) {
             // Do nothing.
         } finally {
-            mAlert.dismiss();
+            if (mAlert != null && mAlert.isShowing()) {
+                mAlert.dismiss();
+            }
         }
     }
 

--- a/packages/SystemUI/src/com/android/systemui/qs/FgsManagerController.kt
+++ b/packages/SystemUI/src/com/android/systemui/qs/FgsManagerController.kt
@@ -232,6 +232,10 @@ constructor(
         resources.getStringArray(com.android.internal.R.array.vendor_stoppable_fgs_system_apps)
     }
 
+    private val hiddenPackages by lazy {
+        resources.getStringArray(R.array.config_hideFgsManagerPackages)
+    }
+
     override fun init() {
         synchronized(lock) {
             if (initialized) {
@@ -727,6 +731,11 @@ constructor(
             private set
 
         fun updateUiControl() {
+            if (hiddenPackages.contains(packageName)) {
+                uiControl = UIControl.HIDE_ENTRY
+                uiControlInitialized = true
+                return
+            }
             backgroundRestrictionExemptionReason =
                 activityManager.getBackgroundRestrictionExemptionReason(uid)
             uiControl =

--- a/services/core/java/com/android/server/appop/AppOpsService.java
+++ b/services/core/java/com/android/server/appop/AppOpsService.java
@@ -139,6 +139,7 @@ import android.os.UserHandle;
 import android.permission.PermissionManager;
 import android.permission.flags.Flags;
 import android.provider.Settings;
+import android.text.TextUtils;
 import android.util.ArrayMap;
 import android.util.ArraySet;
 import android.util.AtomicFile;
@@ -5125,7 +5126,7 @@ public class AppOpsService extends IAppOpsService.Stub {
             @Nullable String attributionTag) {
         if (pkg == null) {
             return false;
-        } else if (attributionTag == null) {
+        } else if (TextUtils.isEmpty(attributionTag)) {
             return true;
         }
         if (pkg.getAttributions() != null) {


### PR DESCRIPTION
This PR accidentally groups four small framework fixes that were originally prepared as separate commits.

Changes:
- `AppOpsService`: treat empty attribution tags as absent, reducing noisy errors from pre-S apps passing an empty tag without manifest `<attribution>` entries.
- `InsetsController`: skip redundant `hide(ime())` logging and unnecessary `ImeTracker` token creation when the IME is already hidden.
- `SystemUI`: add and honor `config_hideFgsManagerPackages` so device overlays can hide selected packages from the FGS manager UI.
- `LogAccessDialogActivity`: clear stale timeout callbacks and guard the final dialog dismiss after configuration changes.

Why:
- reduces recurring log spam
- keeps the FGS manager filtering overlayable and device-specific
- avoids stale timeout interaction with detached dialog state
