### PR TITLE
crowdin: Add calyx_strings.xml for translation

### DIFF
--- a/core/tests/batterystatstests/BatteryStatsViewer/res/values-pt-BR/calyx_strings.xml
+++ b/core/tests/batterystatstests/BatteryStatsViewer/res/values-pt-BR/calyx_strings.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+     SPDX-FileCopyrightText: 2023 The Calyx Institute
+     SPDX-License-Identifier: Apache-2.0
+-->
+<resources>
+    <string name="app_name">Battery Stats Viewer</string>
+    <string name="header">Estatísticas da bateria</string>
+    <string name="display_dashboard_summary">Veja estatísticas detalhadas de uso da bateria</string>
+</resources>

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,5 @@
 files:
   - source: /**/values/evolution_strings.xml
     translation: /%original_path%-%android_code%/%original_file_name%
+  - source: /**/values/calyx_strings.xml
+    translation: /%original_path%-%android_code%/%original_file_name%


### PR DESCRIPTION
Add calyx_strings.xml to Crowdin configuration so BatteryStatsViewer
strings become available for translation via Crowdin.