### PR TITLE
InputMethodManagerService keyboard show retry fix

### DIFF
--- a/services/core/java/com/android/server/inputmethod/InputMethodManagerService.java
+++ b/services/core/java/com/android/server/inputmethod/InputMethodManagerService.java
@@ -115,6 +115,7 @@ import android.os.Trace;
 import android.os.UserHandle;
 import android.os.UserManager;
 import android.provider.Settings;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.util.ArrayMap;
 import android.util.ArraySet;
@@ -2101,6 +2102,9 @@ public final class InputMethodManagerService implements IInputMethodManagerImpl.
             return InputBindResult.NO_IME;
         }
 
+        final boolean retryShowForRealEditor = shouldRetryShowForRealEditorLocked(
+                userData, editorInfo);
+
         if (userData.mCurClient != cs) {
             prepareClientSwitchLocked(cs, userId);
         }
@@ -2141,6 +2145,10 @@ public final class InputMethodManagerService implements IInputMethodManagerImpl.
             return InputBindResult.NO_EDITOR;
         }
 
+        if (retryShowForRealEditor) {
+            visibilityStateComputer.setInputShown(false);
+        }
+
         // Check if the input method is changing.
         // We expect the caller has already verified that the client is allowed to access this
         // display ID.
@@ -2174,6 +2182,26 @@ public final class InputMethodManagerService implements IInputMethodManagerImpl.
 
         bindingController.unbindCurrentMethod();
         return bindingController.bindCurrentMethod();
+    }
+
+    @GuardedBy("ImfLock.class")
+    private boolean shouldRetryShowForRealEditorLocked(@NonNull UserData userData,
+            @NonNull EditorInfo editorInfo) {
+        final var visibilityStateComputer = userData.mVisibilityStateComputer;
+        if (!Flags.reportAnimatingInsetsTypes() || !visibilityStateComputer.isInputShown()) {
+            return false;
+        }
+        if (editorInfo.inputType == InputType.TYPE_NULL) {
+            return false;
+        }
+        final EditorInfo previousEditorInfo = userData.mCurEditorInfo;
+        if (previousEditorInfo != null && previousEditorInfo.inputType != InputType.TYPE_NULL) {
+            return false;
+        }
+        final ImeTargetWindowState targetWindowState = visibilityStateComputer.getWindowStateOrNull(
+                userData.mImeBindingState.mFocusedWindow);
+        return targetWindowState != null && targetWindowState.hasEditorFocused()
+                && targetWindowState.isRequestedImeVisible();
     }
 
     /**


### PR DESCRIPTION
# InputMethodManagerService keyboard show retry fix

```text
InputMethodManagerService: retry IME show after dummy editor handoff

Some launchers briefly attach the IME to a dummy editor while starting an
IME-controlled transition, then replace it with the real search editor a few
milliseconds later.  When reportAnimatingInsetsTypes is enabled, IMMS can mark
the input as already shown for the dummy editor.  If the IME refuses to draw for
that dummy input connection, the following show request for the real editor can
be cancelled as PHASE_SERVER_ALREADY_VISIBLE and the keyboard remains hidden
until the user taps the field again.

Detect the narrow handoff from TYPE_NULL to a real editor while the focused
window still has an editor focused and requested the IME to be visible.  In that
case, clear the cached input-shown state before attaching the new input so the
real editor gets a fresh show path instead of being dropped as already visible.

This does not force-show the IME globally.  The retry is gated on an existing
visible request, a focused editor in the current IME target window, and a
previous TYPE_NULL editor state.
```

## Why this patch exists

The bug is a race between launcher keyboard transitions and the framework IME visibility state.  In the captured log, Pixel Launcher opens All Apps from the QSB/search entry and asks the framework to show the keyboard as part of the insets animation.  The IME is first attached to a placeholder/dummy editor and only afterwards to the real search field.

Gboard refuses to show for the dummy editor:

```text
05-06 16:37:50.621 GoogleInputMethodService: Not showing keyboard because handling dummy ic is disallowed in the current app.
05-06 16:37:50.625 GoogleInputMethodService: Not showing keyboard because handling dummy ic is disallowed in the current app.
```

At the same time, system_server already considers the IME visible/requested and cancels the next server-side show request:

```text
05-06 16:37:50.625 ImeTracker: ... onRequestShow ... reason ATTACH_NEW_INPUT ...
05-06 16:37:50.625 ImeTracker: ... onCancelled at PHASE_SERVER_ALREADY_VISIBLE
```

Immediately after that, the IME receives the dummy editor:

```text
05-06 16:37:50.626 onStartInputView(... inputType=0, inputTypeString=NULL ...)
```

Then the real launcher search field appears:

```text
05-06 16:37:50.642 onStartInput(... inputType=20001, inputTypeString=Normal[MultiLine], actionName=SEARCH, hintText=non-empty ...)
05-06 16:37:50.644 onStartInputView(... inputType=20001, inputTypeString=Normal[MultiLine] ...)
```

The important part is that the real editor arrives, but the earlier show request has already been consumed/cancelled as already visible.  This leaves the UI in a bad state: the launcher thinks the keyboard transition is active, while the IME did not actually become visible for the real search field.

Later manual/user-driven input works:

```text
05-06 16:37:53.305 ImeTracker: ... onRequestShow ... reason SHOW_SOFT_INPUT fromUser true
```

That confirms the failure is not a general Gboard or input-field failure.  It is specifically the automatic show request being lost during the dummy-editor to real-editor handoff.

## What changed in code

The patch touches:

```text
frameworks/base/services/core/java/com/android/server/inputmethod/InputMethodManagerService.java
```

The implementation adds `android.text.InputType` and a helper:

```java
private boolean shouldRetryShowForRealEditorLocked(UserData userData, EditorInfo editorInfo)
```

The helper returns true only when all of these are true:

- `Flags.reportAnimatingInsetsTypes()` is enabled.
- IMMS currently believes input is shown via `visibilityStateComputer.isInputShown()`.
- The new `EditorInfo` is a real editor, not `InputType.TYPE_NULL`.
- The previous `mCurEditorInfo` was null or `InputType.TYPE_NULL`.
- The currently focused IME target window has an editor focused.
- That window requested the IME to be visible.

The boolean is computed before `mCurEditorInfo` is overwritten, because the code needs to compare previous editor state with the incoming editor state.

If the helper says this is the dummy-to-real handoff, the code clears the cached shown state before the new input is attached/reused:

```java
if (retryShowForRealEditor) {
    visibilityStateComputer.setInputShown(false);
}
```

This makes the next attach/show path treat the real editor as needing a fresh show attempt, instead of cancelling it as `PHASE_SERVER_ALREADY_VISIBLE`.

## User-visible behavior fixed

This fixes the case where opening Launcher All Apps/search requests the keyboard, but the keyboard does not appear until the user taps the search field again.

The log pattern for the broken case is:

- Launcher requests an IME-controlled transition.
- IME receives a dummy `EditorInfo` with `inputType=0` / `TYPE_NULL`.
- Gboard refuses to show for dummy input connection.
- IMMS cancels a following show as `PHASE_SERVER_ALREADY_VISIBLE`.
- A real search editor appears immediately after, but the show request has already been lost.

The patch makes the real editor receive a fresh show path.

## Cases covered

This patch is intended for launchers or similar system UI flows that do this:

1. Request IME visibility for a transition or animation.
2. Attach a dummy/null editor while the UI is moving into its final state.
3. Replace the dummy editor with a real text field within the same focused window.

Known affected scenario from the log:

- `com.google.android.apps.nexuslauncher`
- All Apps/search opened from QSB.
- Gboard / GoogleInputMethodService.
- Real editor is the launcher search box with `inputType=20001` and `SEARCH` action.

The fix is not launcher-specific.  It applies to the framework state transition and should also help any app that follows the same dummy-editor handoff pattern.

## What this deliberately does not do

The patch does not force the keyboard to show in arbitrary situations.  It does not bypass normal focus or visibility checks.  It does not run when the incoming editor is still `TYPE_NULL`.  It does not run when the previous editor was already a real editor.  It also does not run if the focused window did not ask for IME visibility.

In other words, the change only repairs a stale framework visibility state after a dummy editor consumed the first show path.