### PR TITLE
SystemUI: Restore launch and routing functionality for QS widgets

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/Dependency.java
+++ b/packages/SystemUI/src/com/android/systemui/Dependency.java
@@ -39,11 +39,13 @@ import com.android.systemui.navigationbar.NavigationBarController;
 import com.android.systemui.navigationbar.NavigationModeController;
 import com.android.systemui.plugins.DarkIconDispatcher;
 import com.android.systemui.plugins.PluginManager;
+import com.android.systemui.plugins.ActivityStarter;
 import com.android.systemui.plugins.VolumeDialogController;
 import com.android.systemui.plugins.statusbar.StatusBarStateController;
 import com.android.systemui.rotation.RotationPolicyWrapper;
 import com.android.systemui.settings.UserTracker;
 import com.android.systemui.statusbar.CommandQueue;
+import com.android.systemui.statusbar.NotificationLockscreenUserManager;
 import com.android.systemui.statusbar.notification.collection.render.GroupExpansionManager;
 import com.android.systemui.statusbar.notification.collection.render.GroupMembershipManager;
 import com.android.systemui.statusbar.notification.stack.AmbientState;
@@ -123,6 +125,7 @@ public class Dependency {
     @Inject Lazy<KeyguardUpdateMonitor> mKeyguardUpdateMonitor;
     @Inject Lazy<DeviceProvisionedController> mDeviceProvisionedController;
     @Inject Lazy<PluginManager> mPluginManager;
+    @Inject Lazy<ActivityStarter> mActivityStarter;
     @Inject Lazy<AssistManager> mAssistManager;
     @Inject Lazy<TunerService> mTunerService;
     @Inject Lazy<DarkIconDispatcher> mDarkIconDispatcher;
@@ -150,6 +153,7 @@ public class Dependency {
     @Inject Lazy<GroupExpansionManager> mGroupExpansionManagerLazy;
     @Inject Lazy<SystemUIDialogManager> mSystemUIDialogManagerLazy;
     @Inject Lazy<DialogTransitionAnimator> mDialogTransitionAnimatorLazy;
+    @Inject Lazy<NotificationLockscreenUserManager> mNotificationLockscreenUserManagerLazy;
     @Inject Lazy<UserTracker> mUserTrackerLazy;
     @Inject Lazy<StatusBarWindowControllerStore> mStatusBarWindowControllerStoreLazy;
     @Inject Lazy<SysUIStateDisplaysInteractor> mSysUIStateDisplaysInteractor;
@@ -173,6 +177,7 @@ public class Dependency {
         mProviders.put(KeyguardUpdateMonitor.class, mKeyguardUpdateMonitor::get);
         mProviders.put(DeviceProvisionedController.class, mDeviceProvisionedController::get);
         mProviders.put(PluginManager.class, mPluginManager::get);
+        mProviders.put(ActivityStarter.class, mActivityStarter::get);
         mProviders.put(AssistManager.class, mAssistManager::get);
         mProviders.put(TunerService.class, mTunerService::get);
         mProviders.put(DarkIconDispatcher.class, mDarkIconDispatcher::get);
@@ -197,6 +202,7 @@ public class Dependency {
         mProviders.put(GroupExpansionManager.class, mGroupExpansionManagerLazy::get);
         mProviders.put(SystemUIDialogManager.class, mSystemUIDialogManagerLazy::get);
         mProviders.put(DialogTransitionAnimator.class, mDialogTransitionAnimatorLazy::get);
+        mProviders.put(NotificationLockscreenUserManager.class, mNotificationLockscreenUserManagerLazy::get);
         mProviders.put(UserTracker.class, mUserTrackerLazy::get);
         mProviders.put(SysUIStateDisplaysInteractor.class, mSysUIStateDisplaysInteractor::get);
         mProviders.put(

--- a/packages/SystemUI/src/com/android/systemui/qs/panels/ui/compose/IosMusicPlayer.kt
+++ b/packages/SystemUI/src/com/android/systemui/qs/panels/ui/compose/IosMusicPlayer.kt
@@ -16,7 +16,10 @@
 
 package com.android.systemui.qs.panels.ui.compose
 
+import android.app.PendingIntent
 import android.content.Context
+import android.content.ComponentName
+import android.content.Intent
 import android.graphics.Bitmap
 import android.media.MediaMetadata
 import android.media.session.MediaController
@@ -36,6 +39,7 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -85,7 +89,15 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+import com.android.settingslib.media.MediaOutputConstants
+
+import com.android.systemui.ActivityIntentHelper
+import com.android.systemui.Dependency
+import com.android.systemui.media.dialog.MediaOutputDialogReceiver
+import com.android.systemui.plugins.ActivityStarter
 import com.android.systemui.qs.panels.ui.compose.infinitegrid.CustomColorScheme
+import com.android.systemui.statusbar.NotificationLockscreenUserManager
+import com.android.systemui.statusbar.policy.KeyguardStateController
 
 private data class IosMusicPlayerState(
     val title: String? = null,
@@ -101,6 +113,11 @@ fun IosMusicPlayer(modifier: Modifier = Modifier) {
     val sessionManager = remember {
         context.getSystemService(Context.MEDIA_SESSION_SERVICE) as? MediaSessionManager
     }
+
+    val keyguardStateController = remember { Dependency.get(KeyguardStateController::class.java) }
+    val activityIntentHelper = remember { ActivityIntentHelper(context) }
+    val activityStarter = remember { Dependency.get(ActivityStarter::class.java) }
+    val lockscreenUserManager = remember { Dependency.get(NotificationLockscreenUserManager::class.java) }
 
     var mediaState by remember { mutableStateOf(IosMusicPlayerState()) }
 
@@ -169,12 +186,26 @@ fun IosMusicPlayer(modifier: Modifier = Modifier) {
         }
     }
 
-    IosMusicPlayerContent(mediaState = mediaState, modifier = modifier)
+    IosMusicPlayerContent(
+        mediaState = mediaState, 
+        activityStarter = activityStarter, 
+        keyguardStateController = keyguardStateController,
+        activityIntentHelper = activityIntentHelper, 
+        lockscreenUserManager = lockscreenUserManager,
+        modifier = modifier, 
+    )
 }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun IosMusicPlayerContent(mediaState: IosMusicPlayerState, modifier: Modifier = Modifier) {
+private fun IosMusicPlayerContent(
+    mediaState: IosMusicPlayerState, 
+    activityStarter: ActivityStarter,
+    keyguardStateController: KeyguardStateController,
+    activityIntentHelper: ActivityIntentHelper,
+    lockscreenUserManager: NotificationLockscreenUserManager,
+    modifier: Modifier = Modifier
+) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -285,7 +316,37 @@ private fun IosMusicPlayerContent(mediaState: IosMusicPlayerState, modifier: Mod
                 .padding(horizontal = 14.dp, vertical = 12.dp),
             verticalArrangement = Arrangement.SpaceBetween,
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.clickable(enabled = mediaState?.controller != null) {
+                    val pkg = mediaState?.controller?.packageName ?: return@clickable
+                    val pending = mediaState?.controller?.sessionActivity ?: context.packageManager
+                        .getLaunchIntentForPackage(pkg)
+                        ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        ?.let { PendingIntent.getActivity(context, 0, it, PendingIntent.FLAG_IMMUTABLE) }
+                        ?: return@clickable
+
+                    val showOverLockscreen = keyguardStateController.isShowing &&
+                        activityIntentHelper.wouldPendingShowOverLockscreen(
+                            pending,
+                            lockscreenUserManager.currentUserId
+                        )
+
+                    if (showOverLockscreen) {
+                        activityStarter.startPendingIntentMaybeDismissingKeyguard(
+                            pending,
+                            /* dismissShade = */ true,
+                            /* intentSentUiThreadCallback = */ null,
+                            /* animationController = */ null,
+                            /* fillIntent = */ null,
+                            /* extraOptions = */ null,
+                            /* customMessage = */ null
+                        )
+                    } else {
+                        activityStarter.postStartActivityDismissingKeyguard(pending, null)
+                    }
+                }
+            ) {
                 if (mediaState.albumArt != null) {
                     Image(
                         painter = BitmapPainter(mediaState.albumArt.asImageBitmap()),
@@ -345,6 +406,16 @@ private fun IosMusicPlayerContent(mediaState: IosMusicPlayerState, modifier: Mod
                             if (hasMedia) Color.Black.copy(alpha = 0.3f)
                             else MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.7f)
                         )
+                        .clickable(true) {
+                            val pkg = mediaState?.controller?.packageName ?: return@clickable
+                            val intent = Intent(MediaOutputConstants.ACTION_LAUNCH_MEDIA_OUTPUT_DIALOG).apply {
+                                    putExtra(MediaOutputConstants.EXTRA_PACKAGE_NAME, pkg)
+                                    component = ComponentName("com.android.systemui", MediaOutputDialogReceiver::class.java.name)
+                                }
+                            if (pkg != null) {
+                                context.sendBroadcast(intent)
+                            }
+                        }
                         .padding(horizontal = 6.dp, vertical = 4.dp),
                     contentAlignment = Alignment.Center,
                 ) {

--- a/packages/SystemUI/src/com/android/systemui/qs/panels/ui/compose/MaterialMusicPlayer.kt
+++ b/packages/SystemUI/src/com/android/systemui/qs/panels/ui/compose/MaterialMusicPlayer.kt
@@ -16,7 +16,10 @@
 
 package com.android.systemui.qs.panels.ui.compose
 
+import android.app.PendingIntent
 import android.content.Context
+import android.content.ComponentName
+import android.content.Intent
 import android.graphics.Bitmap
 import android.media.AudioDeviceCallback
 import android.media.AudioDeviceInfo
@@ -88,7 +91,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
+import com.android.settingslib.media.MediaOutputConstants
+
+import com.android.systemui.ActivityIntentHelper
+import com.android.systemui.Dependency
+import com.android.systemui.media.dialog.MediaOutputDialogReceiver
 import com.android.systemui.qs.panels.ui.compose.infinitegrid.CustomColorScheme
+import com.android.systemui.plugins.ActivityStarter
+import com.android.systemui.statusbar.NotificationLockscreenUserManager
+import com.android.systemui.statusbar.policy.KeyguardStateController
 
 private data class MediaState(
     val title: String? = null,
@@ -100,11 +111,16 @@ private data class MediaState(
 )
 
 @Composable
-fun MaterialMusicPlayer(modifier: Modifier = Modifier) {
+fun MaterialMusicPlayer(modifier: Modifier = Modifier)  {
     val context = LocalContext.current
     val sessionManager = remember {
         context.getSystemService(Context.MEDIA_SESSION_SERVICE) as? MediaSessionManager
     }
+
+    val keyguardStateController = remember { Dependency.get(KeyguardStateController::class.java) }
+    val activityIntentHelper = remember { ActivityIntentHelper(context) }
+    val activityStarter = remember { Dependency.get(ActivityStarter::class.java) }
+    val lockscreenUserManager = remember { Dependency.get(NotificationLockscreenUserManager::class.java) }
 
     var mediaState by remember { mutableStateOf(MediaState()) }
 
@@ -174,7 +190,14 @@ fun MaterialMusicPlayer(modifier: Modifier = Modifier) {
         }
     }
 
-    MaterialMusicPlayerContent(mediaState = mediaState, modifier = modifier)
+    MaterialMusicPlayerContent(
+        mediaState = mediaState, 
+        keyguardStateController = keyguardStateController,
+        activityStarter = activityStarter,
+        activityIntentHelper = activityIntentHelper, 
+        lockscreenUserManager = lockscreenUserManager,
+        modifier = modifier, 
+    )
 }
 
 @Composable
@@ -248,7 +271,14 @@ private fun SkipButton(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun MaterialMusicPlayerContent(mediaState: MediaState, modifier: Modifier = Modifier) {
+private fun MaterialMusicPlayerContent(
+    mediaState: MediaState, 
+    keyguardStateController: KeyguardStateController,
+    activityStarter: ActivityStarter,
+    activityIntentHelper: ActivityIntentHelper,
+    lockscreenUserManager: NotificationLockscreenUserManager,
+    modifier: Modifier = Modifier
+) {
     val context = LocalContext.current
     val tileColor = CustomColorScheme.current.qsTileColor
 
@@ -332,7 +362,36 @@ private fun MaterialMusicPlayerContent(mediaState: MediaState, modifier: Modifie
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(enabled = mediaState?.controller != null) {
+                        val pkg = mediaState?.controller?.packageName ?: return@clickable
+                        val pending = mediaState?.controller?.sessionActivity ?: context.packageManager
+                            .getLaunchIntentForPackage(pkg)
+                            ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            ?.let { PendingIntent.getActivity(context, 0, it, PendingIntent.FLAG_IMMUTABLE) }
+                            ?: return@clickable
+
+                        val showOverLockscreen = keyguardStateController.isShowing &&
+                            activityIntentHelper.wouldPendingShowOverLockscreen(
+                                pending,
+                                lockscreenUserManager.currentUserId
+                            )
+
+                        if (showOverLockscreen) {
+                            activityStarter.startPendingIntentMaybeDismissingKeyguard(
+                                pending,
+                                /* dismissShade = */ true,
+                                /* intentSentUiThreadCallback = */ null,
+                                /* animationController = */ null,
+                                /* fillIntent = */ null,
+                                /* extraOptions = */ null,
+                                /* customMessage = */ null
+                            )
+                        } else {
+                            activityStarter.postStartActivityDismissingKeyguard(pending, null)
+                        }
+                    }
             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
@@ -370,6 +429,16 @@ private fun MaterialMusicPlayerContent(mediaState: MediaState, modifier: Modifie
                             if (mediaState.albumArt != null) Color.Black.copy(alpha = 0.3f)
                             else MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.7f)
                         )
+                        .clickable(true) {
+                            val pkg = mediaState?.controller?.packageName ?: return@clickable
+                            val intent = Intent(MediaOutputConstants.ACTION_LAUNCH_MEDIA_OUTPUT_DIALOG).apply {
+                                    putExtra(MediaOutputConstants.EXTRA_PACKAGE_NAME, pkg)
+                                    component = ComponentName("com.android.systemui", MediaOutputDialogReceiver::class.java.name)
+                                }
+                            if (pkg != null) {
+                                context.sendBroadcast(intent)
+                            }
+                        }
                         .padding(horizontal = 6.dp, vertical = 4.dp),
                     contentAlignment = Alignment.Center,
                 ) {


### PR DESCRIPTION
- Route icon now launches the dialog like it used to
- Tapping on title/artist (album art if iOS style) will launch the playing application