### PR TITLE
SystemUI: Fix QS widget brightness slider jumping after hold trigger

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/panels/ui/compose/MaterialVerticalBrightnessSlider.kt
+++ b/packages/SystemUI/src/com/android/systemui/qs/panels/ui/compose/MaterialVerticalBrightnessSlider.kt
@@ -232,8 +232,8 @@ fun MaterialVerticalBrightnessSlider(
                     view.parent?.requestDisallowInterceptTouchEvent(true)
 
                     val downLinear = yToLinear(down.position.y, size.height)
-                    linearBrightness = downLinear
-                    writeLinearBrightness(downLinear)
+                    val downTime = System.currentTimeMillis()
+                    var dragging = false
 
                     longPressJob = scope.launch {
                         delay(500)
@@ -254,12 +254,19 @@ fun MaterialVerticalBrightnessSlider(
                         view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
                     }
 
-                    var dragging = false
                     try {
                         while (true) {
                             val event = awaitPointerEvent(PointerEventPass.Main)
                             val ptr = event.changes.firstOrNull { it.id == down.id } ?: break
-                            if (!ptr.pressed) { longPressJob?.cancel(); break }
+                            if (!ptr.pressed) {
+                                val heldMs = System.currentTimeMillis() - downTime
+                                if (!dragging && heldMs < 500) {
+                                    linearBrightness = downLinear
+                                    writeLinearBrightness(downLinear)
+                                }
+                                longPressJob?.cancel()
+                                break
+                            }
 
                             val dragAmt = ptr.position.y - down.position.y
                             if (!dragging && abs(dragAmt) > viewConfiguration.touchSlop) {


### PR DESCRIPTION
The hold action switches between manual and auto brightness, but before this it was snapping to wherever the user was holding on the slider even after the action ran.