### PR TITLE
WindowManager: Make Screenshot detection and Screenrecord detection configurable [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -21863,6 +21863,20 @@ public final class Settings {
         public static final String SCENE_CONTAINER_ENABLED = "scene_container_enabled";
 
         /**
+         * Whether Evolution X should block screenshot detection.
+         * 
+         * @hide
+         */
+        public static final String EVOLUTION_WINDOW_BLOCK_SCREENSHOT_DETECTION = "window_block_screenshot_detection";
+
+        /**
+         * Whether Evolution X should block screen recording detection.
+         * 
+         * @hide
+         */
+        public static final String EVOLUTION_WINDOW_BLOCK_SCREENRECORD_DETECTION = "window_block_screenrecord_detection";
+
+        /**
          * Settings migrated from Wear OS settings provider.
          * @hide
          */

--- a/services/core/java/com/android/server/wm/ScreenRecordingCallbackController.java
+++ b/services/core/java/com/android/server/wm/ScreenRecordingCallbackController.java
@@ -24,6 +24,7 @@ import android.media.projection.IMediaProjectionManager;
 import android.media.projection.IMediaProjectionWatcherCallback;
 import android.media.projection.MediaProjectionEvent;
 import android.media.projection.MediaProjectionInfo;
+import android.provider.Settings;
 import android.os.Binder;
 import android.os.IBinder;
 import android.os.RemoteException;
@@ -154,6 +155,11 @@ public class ScreenRecordingCallbackController {
             }
 
             boolean uidInRecording = uidHasRecordedActivity(callbackInfo.mUid);
+
+            if (isScreenRecordDetectionBlocked()) {
+                uidInRecording = false;
+            }
+
             mLastInvokedStateByUid.put(callbackInfo.mUid, uidInRecording);
             mCallbacks.put(binder, callbackInfo);
             return uidInRecording;
@@ -265,8 +271,12 @@ public class ScreenRecordingCallbackController {
             return;
         }
 
+        final boolean callbackState = isScreenRecordDetectionBlocked()
+            ? false
+            : visibleInScreenRecording;
+
         for (int i = 0; i < uids.size(); i++) {
-            mLastInvokedStateByUid.put(uids.valueAt(i), visibleInScreenRecording);
+            mLastInvokedStateByUid.put(uids.valueAt(i), callbackState);
         }
 
         ArrayList<IScreenRecordingCallback> callbacks = new ArrayList<>();
@@ -279,12 +289,18 @@ public class ScreenRecordingCallbackController {
         mWms.mH.post(() -> {
             for (int i = 0; i < callbacks.size(); i++) {
                 try {
-                    callbacks.get(i).onScreenRecordingStateChanged(visibleInScreenRecording);
+                    callbacks.get(i).onScreenRecordingStateChanged(callbackState);
                 } catch (RemoteException e) {
                     // Client has died. Cleanup is handled via DeathRecipient.
                 }
             }
         });
+    }
+
+    private boolean isScreenRecordDetectionBlocked() {
+        return Settings.Global.getInt(mWms.mContext.getContentResolver(),
+                Settings.Global.EVOLUTION_WINDOW_BLOCK_SCREENRECORD_DETECTION, 0)
+            != 0;
     }
 
     void dump(PrintWriter pw) {

--- a/services/core/java/com/android/server/wm/WindowManagerService.java
+++ b/services/core/java/com/android/server/wm/WindowManagerService.java
@@ -61,6 +61,7 @@ import static android.provider.Settings.Global.DEVELOPMENT_ENABLE_NON_RESIZABLE_
 import static android.provider.Settings.Global.DEVELOPMENT_FORCE_DESKTOP_MODE_ON_EXTERNAL_DISPLAYS;
 import static android.provider.Settings.Global.DEVELOPMENT_FORCE_RESIZABLE_ACTIVITIES;
 import static android.provider.Settings.Global.DEVELOPMENT_WM_DISPLAY_SETTINGS_PATH;
+import static android.provider.Settings.Global.EVOLUTION_WINDOW_BLOCK_SCREENSHOT_DETECTION;
 import static android.service.dreams.Flags.dreamHandlesConfirmKeys;
 import static android.view.ContentRecordingSession.RECORD_CONTENT_TASK;
 import static android.view.Display.DEFAULT_DISPLAY;
@@ -793,6 +794,9 @@ public class WindowManagerService extends IWindowManager.Stub
     boolean mIsTouchDevice;
     boolean mIsFakeTouchDevice;
 
+    // Cache Screenshot detection block preference
+    private boolean mEvolutionWindowBlockScreenshotDetection = false;
+
     final H mH = new H();
 
     /**
@@ -865,6 +869,8 @@ public class WindowManagerService extends IWindowManager.Stub
                 Settings.Global.MAXIMUM_OBSCURING_OPACITY_FOR_TOUCH);
         private final Uri mDevelopmentOverrideDesktopExperienceUri = Settings.Global.getUriFor(
                 Settings.Global.DEVELOPMENT_OVERRIDE_DESKTOP_EXPERIENCE_FEATURES);
+        private final Uri mEvolutionBlockScreenshotDetectionUri = Settings.Global.getUriFor(
+                Settings.Global.EVOLUTION_WINDOW_BLOCK_SCREENSHOT_DETECTION);
 
         public SettingsObserver() {
             super(new Handler());
@@ -906,6 +912,8 @@ public class WindowManagerService extends IWindowManager.Stub
             resolver.registerContentObserver(mMaximumObscuringOpacityForTouchUri, false, this,
                     UserHandle.USER_ALL);
             resolver.registerContentObserver(mDevelopmentOverrideDesktopExperienceUri, false, this,
+                    UserHandle.USER_ALL);
+            resolver.registerContentObserver(mEvolutionBlockScreenshotDetectionUri, false, this,
                     UserHandle.USER_ALL);
         }
 
@@ -959,6 +967,11 @@ public class WindowManagerService extends IWindowManager.Stub
                 return;
             }
 
+            if (mEvolutionBlockScreenshotDetectionUri.equals(uri)) {
+                updateEvolutionBlockScreenshotDetection();
+                return;
+            }
+
             @UpdateAnimationScaleMode
             final int mode;
             if (mWindowAnimationScaleUri.equals(uri)) {
@@ -979,6 +992,7 @@ public class WindowManagerService extends IWindowManager.Stub
             updateMaximumObscuringOpacityForTouch();
             updateDisableSecureWindows();
             updateMagnifyIme();
+            updateEvolutionBlockScreenshotDetection();
         }
 
         void updateMaximumObscuringOpacityForTouch() {
@@ -1101,6 +1115,14 @@ public class WindowManagerService extends IWindowManager.Stub
             synchronized (mGlobalLock) {
                 mMagnifyIme = enabledMagnifyIme;
             }
+        }
+
+        void updateEvolutionBlockScreenshotDetection() {
+            final ContentResolver resolver = mContext.getContentResolver();
+            mEvolutionWindowBlockScreenshotDetection = Settings.Global.getInt(
+                    resolver,
+                    EVOLUTION_WINDOW_BLOCK_SCREENSHOT_DETECTION,
+                    0) != 0;
         }
     }
 
@@ -11207,6 +11229,11 @@ public class WindowManagerService extends IWindowManager.Stub
                 "notifyScreenshotListeners()")) {
             throw new SecurityException("Requires STATUS_BAR_SERVICE permission");
         }
+
+        if (mEvolutionWindowBlockScreenshotDetection) {
+            return new ArrayList<>();
+        }
+
         synchronized (mGlobalLock) {
             final DisplayContent displayContent = mRoot.getDisplayContent(displayId);
             if (displayContent == null) {


### PR DESCRIPTION
Adds two new toggles to bypass Android's app notification mechanisms for screenshot and screen recording detection. These bypasses are transparent to applications.

Screenshot detection: When enabled, Window Manager prevents registered applications from receiving the screenshot notification, so apps cannot detect that their content was screenshotted.

Screen recording detection: When enabled, Window Manager masks the screen recording state reported through IScreenRecordingCallback, always reporting that the application's content is not being recorded. Screen recording itself is unaffected.